### PR TITLE
BDEV-19651 made docker-client jakarta compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Released January 16, 2019
 [1132]: https://github.com/spotify/docker-client/pull/1132
 [1111]: https://github.com/spotify/docker-client/pull/1111
 
+## 9.0.0-atlassian-1
+- Migration to jakarta namespace
+- Minimum required Java version is 17
+
 ## 8.14.5
 
 - Support for Windows 10 Docker named pipes ([875][])

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ If you're looking for how to build and develop it, keep reading.
 
 ## Prerequisites
 
-docker-client should be buildable on any platform with Docker 1.6+, JDK8+, and a recent version of
+docker-client should be buildable on any platform with Docker 1.6+, JDK17+, and a recent version of
 Maven 3.
 
 ### A note on using Docker for Mac

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.spotify</groupId>
   <artifactId>docker-client</artifactId>
-  <version>8.16.1-atlassian-16-SNAPSHOT</version>
+  <version>9.0.0-atlassian-1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>docker-client</name>
   <description>A docker client</description>
@@ -106,22 +106,27 @@
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-client</artifactId>
-      <version>2.22.2</version>
+      <version>3.1.9</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.connectors</groupId>
       <artifactId>jersey-apache-connector</artifactId>
-      <version>2.22.2</version>
+      <version>3.1.9</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
-      <version>2.22.2</version>
+      <version>3.1.9</version>
     </dependency>
     <dependency>
-      <groupId>javax.activation</groupId>
-      <artifactId>activation</artifactId>
-      <version>1.1</version>
+      <groupId>jakarta.activation</groupId>
+      <artifactId>jakarta.activation-api</artifactId>
+      <version>2.1.3</version>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+      <version>2.1.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -160,8 +165,13 @@
     </dependency>
     <dependency>
       <groupId>com.google.auto.value</groupId>
+      <artifactId>auto-value-annotations</artifactId>
+      <version>1.11.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value</artifactId>
-      <version>1.3</version>
+      <version>1.11.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -262,10 +272,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>3.13.0</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>17</source>
+          <target>17</target>
         </configuration>
       </plugin>
       <plugin>
@@ -308,8 +318,8 @@
           <artifactSet>
             <includes>
               <include>com.fasterxml.jackson.**</include>
-              <include>javax.annotation:*</include>
-              <include>javax.ws.rs:*</include>
+              <include>jakarta.annotation:*</include>
+              <include>jakarta.ws.rs:*</include>
               <include>org.glassfish.**</include>
               <include>org.jvnet.hk2.**</include>
               <include>com.github.jnr:*</include>
@@ -325,16 +335,16 @@
           </artifactSet>
           <relocations>
             <relocation>
-              <pattern>javax.annotation</pattern>
-              <shadedPattern>com.spotify.docker.client.shaded.javax.annotation</shadedPattern>
+              <pattern>jakarta.annotation</pattern>
+              <shadedPattern>com.spotify.docker.client.shaded.jakarta.annotation</shadedPattern>
             </relocation>
             <relocation>
-              <pattern>javax.inject</pattern>
-              <shadedPattern>com.spotify.docker.client.shaded.javax.inject</shadedPattern>
+              <pattern>jakarta.inject</pattern>
+              <shadedPattern>com.spotify.docker.client.shaded.jakarta.inject</shadedPattern>
             </relocation>
             <relocation>
-              <pattern>javax.ws.rs</pattern>
-              <shadedPattern>com.spotify.docker.client.shaded.javax.ws.rs</shadedPattern>
+              <pattern>jakarta.ws.rs</pattern>
+              <shadedPattern>com.spotify.docker.client.shaded.jakarta.ws.rs</shadedPattern>
             </relocation>
             <relocation>
               <pattern>org.glassfish</pattern>

--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -33,14 +33,14 @@ import static com.spotify.docker.client.VersionCompare.compareVersion;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonMap;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static javax.ws.rs.HttpMethod.DELETE;
-import static javax.ws.rs.HttpMethod.GET;
-import static javax.ws.rs.HttpMethod.POST;
-import static javax.ws.rs.HttpMethod.PUT;
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
-import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM;
-import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM_TYPE;
-import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
+import static jakarta.ws.rs.HttpMethod.DELETE;
+import static jakarta.ws.rs.HttpMethod.GET;
+import static jakarta.ws.rs.HttpMethod.POST;
+import static jakarta.ws.rs.HttpMethod.PUT;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM_TYPE;
+import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -162,18 +162,18 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import javax.ws.rs.ProcessingException;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.Invocation;
-import javax.ws.rs.client.ResponseProcessingException;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.ProcessingException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.client.ResponseProcessingException;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.compress.utils.IOUtils;
@@ -191,7 +191,6 @@ import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.conn.BasicHttpClientConnectionManager;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
-import org.glassfish.hk2.api.MultiException;
 import org.glassfish.jersey.apache.connector.ApacheClientProperties;
 import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
 import org.glassfish.jersey.client.ClientConfig;
@@ -2703,7 +2702,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
       throws DockerException, InterruptedException {
     try {
       return headers(request).async().method(method, type).get();
-    } catch (ExecutionException | MultiException e) {
+    } catch (ExecutionException e) {
       throw propagate(method, resource, e);
     }
   }
@@ -2713,7 +2712,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
       throws DockerException, InterruptedException {
     try {
       return headers(request).async().method(method, clazz).get();
-    } catch (ExecutionException | MultiException e) {
+    } catch (ExecutionException e) {
       throw propagate(method, resource, e);
     }
   }
@@ -2724,7 +2723,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
       throws DockerException, InterruptedException {
     try {
       return headers(request).async().method(method, entity, clazz).get();
-    } catch (ExecutionException | MultiException e) {
+    } catch (ExecutionException  e) {
       throw propagate(method, resource, e);
     }
   }
@@ -2735,7 +2734,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
       throws DockerException, InterruptedException {
     try {
       headers(request).async().method(method, String.class).get();
-    } catch (ExecutionException | MultiException e) {
+    } catch (ExecutionException e) {
       throw propagate(method, resource, e);
     }
   }
@@ -2821,13 +2820,6 @@ public class DefaultDockerClient implements DockerClient, Closeable {
                                      final Exception ex)
       throws DockerException, InterruptedException {
     Throwable cause = ex.getCause();
-
-    // Sometimes e is a org.glassfish.hk2.api.MultiException
-    // which contains the cause we're actually interested in.
-    // So we unpack it here.
-    if (ex instanceof MultiException) {
-      cause = cause.getCause();
-    }
 
     Response response = null;
     if (cause instanceof ResponseProcessingException) {

--- a/src/main/java/com/spotify/docker/client/DockerConfig.java
+++ b/src/main/java/com/spotify/docker/client/DockerConfig.java
@@ -31,7 +31,7 @@ import com.google.common.collect.ImmutableMap;
 import com.spotify.docker.client.messages.RegistryAuth;
 
 import java.util.Map;
-import javax.annotation.Nullable;
+
 
 /**
  * Represents the contents of the docker config.json file.
@@ -40,35 +40,35 @@ import javax.annotation.Nullable;
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
 public abstract class DockerConfig {
 
-  @Nullable
+
   @JsonProperty("credHelpers")
   public abstract ImmutableMap<String, String> credHelpers();
 
-  @Nullable
+
   @JsonProperty("auths")
   public abstract ImmutableMap<String, RegistryAuth> auths();
 
-  @Nullable
+
   @JsonProperty("HttpHeaders")
   public abstract ImmutableMap<String, String> httpHeaders();
 
-  @Nullable
+
   @JsonProperty("credsStore")
   public abstract String credsStore();
 
-  @Nullable
+
   @JsonProperty("detachKeys")
   public abstract String detachKeys();
 
-  @Nullable
+
   @JsonProperty("stackOrchestrator")
   public abstract String stackOrchestrator();
 
-  @Nullable
+
   @JsonProperty("psFormat")
   public abstract String psFormat();
 
-  @Nullable
+
   @JsonProperty("imagesFormat")
   public abstract String imagesFormat();
 

--- a/src/main/java/com/spotify/docker/client/LogsResponseReader.java
+++ b/src/main/java/com/spotify/docker/client/LogsResponseReader.java
@@ -25,10 +25,10 @@ import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyReader;
 
 public class LogsResponseReader implements MessageBodyReader<LogStream> {
 

--- a/src/main/java/com/spotify/docker/client/ObjectMapperProvider.java
+++ b/src/main/java/com/spotify/docker/client/ObjectMapperProvider.java
@@ -40,9 +40,9 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.ext.ContextResolver;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.ext.ContextResolver;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/com/spotify/docker/client/ProgressResponseReader.java
+++ b/src/main/java/com/spotify/docker/client/ProgressResponseReader.java
@@ -25,10 +25,10 @@ import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyReader;
 
 public class ProgressResponseReader implements MessageBodyReader<ProgressStream> {
 

--- a/src/main/java/com/spotify/docker/client/exceptions/DockerRequestException.java
+++ b/src/main/java/com/spotify/docker/client/exceptions/DockerRequestException.java
@@ -21,7 +21,7 @@
 package com.spotify.docker.client.exceptions;
 
 import java.net.URI;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 public class DockerRequestException extends DockerException {
 

--- a/src/main/java/com/spotify/docker/client/messages/AttachedNetwork.java
+++ b/src/main/java/com/spotify/docker/client/messages/AttachedNetwork.java
@@ -30,7 +30,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 
 @AutoValue

--- a/src/main/java/com/spotify/docker/client/messages/BlockIoStats.java
+++ b/src/main/java/com/spotify/docker/client/messages/BlockIoStats.java
@@ -29,7 +29,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/Container.java
+++ b/src/main/java/com/spotify/docker/client/messages/Container.java
@@ -32,7 +32,7 @@ import com.google.common.collect.ImmutableMap;
 
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerConfig.java
@@ -31,14 +31,10 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
@@ -104,6 +100,7 @@ public abstract class ContainerConfig {
    * @deprecated As of 8.10.0, use {@link #volumes()}.
    */
   @Deprecated
+  @Nullable
   public Set<String> volumeNames() {
     return volumes();
   }
@@ -176,7 +173,7 @@ public abstract class ContainerConfig {
       @JsonProperty("Env") final List<String> env,
       @JsonProperty("Cmd") final List<String> cmd,
       @JsonProperty("Image") final String image,
-      @JsonProperty("Volumes") final Set<String> volumes,
+      @Nullable @JsonProperty("Volumes") final Set<String> volumes,
       @JsonProperty("WorkingDir") final String workingDir,
       @JsonProperty("Entrypoint") final List<String> entrypoint,
       @JsonProperty("NetworkDisabled") final Boolean networkDisabled,
@@ -260,34 +257,19 @@ public abstract class ContainerConfig {
     public abstract Builder cmd(final String... cmd);
 
     public abstract Builder image(final String image);
-
-    abstract ImmutableSet.Builder<String> volumesBuilder();
-
-    public Builder addVolume(final String volume) {
-      volumesBuilder().add(volume);
-      return this;
-    }
-
-    public Builder addVolumes(final String... volumes) {
-      for (final String volume : volumes) {
-        volumesBuilder().add(volume);
-      }
-      return this;
-    }
-
     /**
      * @deprecated As of 8.10.0, use {@link #volumes(Set)} or
      *             {@link #volumes(String...)}.
      */
     @Deprecated
-    public Builder volumes(final Map<String, Map> volumes) {
+    public @Nullable Builder volumes(@Nullable final Map<String, Map> volumes) {
       this.volumes(volumes.keySet());
       return this;
     }
 
-    public abstract Builder volumes(final Set<String> volumes);
+    public abstract Builder volumes(@Nullable final Set<String> volumes);
 
-    public abstract Builder volumes(final String... volumes);
+    public  abstract Builder volumes(@Nullable final String... volumes);
 
     public abstract Builder workingDir(final String workingDir);
 

--- a/src/main/java/com/spotify/docker/client/messages/ContainerCreation.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerCreation.java
@@ -30,7 +30,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/ContainerInfo.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerInfo.java
@@ -34,7 +34,7 @@ import java.util.Date;
 
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, setterVisibility = NONE, getterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/ContainerMount.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerMount.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 
 @AutoValue

--- a/src/main/java/com/spotify/docker/client/messages/ContainerState.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerState.java
@@ -32,7 +32,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.Date;
 import java.util.List;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/ContainerStats.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerStats.java
@@ -31,7 +31,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import java.util.Date;
 import java.util.Map;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/ContainerUpdate.java
+++ b/src/main/java/com/spotify/docker/client/messages/ContainerUpdate.java
@@ -30,7 +30,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/CpuStats.java
+++ b/src/main/java/com/spotify/docker/client/messages/CpuStats.java
@@ -29,7 +29,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/Device.java
+++ b/src/main/java/com/spotify/docker/client/messages/Device.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/Distribution.java
+++ b/src/main/java/com/spotify/docker/client/messages/Distribution.java
@@ -29,7 +29,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = DEFAULT)

--- a/src/main/java/com/spotify/docker/client/messages/DockerCredentialHelperAuth.java
+++ b/src/main/java/com/spotify/docker/client/messages/DockerCredentialHelperAuth.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 /**
  * Represents the auth response received from a docker credential helper

--- a/src/main/java/com/spotify/docker/client/messages/EndpointConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/EndpointConfig.java
@@ -29,7 +29,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/Event.java
+++ b/src/main/java/com/spotify/docker/client/messages/Event.java
@@ -37,7 +37,7 @@ import com.spotify.docker.client.jackson.UnixTimestampSerializer;
 import java.util.Date;
 import java.util.Map;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, setterVisibility = NONE, getterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/ExecCreation.java
+++ b/src/main/java/com/spotify/docker/client/messages/ExecCreation.java
@@ -31,7 +31,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/ExecState.java
+++ b/src/main/java/com/spotify/docker/client/messages/ExecState.java
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 /**
  * An object that represents the JSON returned by the Docker API for low-level information about

--- a/src/main/java/com/spotify/docker/client/messages/HostConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/HostConfig.java
@@ -41,7 +41,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/Image.java
+++ b/src/main/java/com/spotify/docker/client/messages/Image.java
@@ -32,7 +32,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/ImageHistory.java
+++ b/src/main/java/com/spotify/docker/client/messages/ImageHistory.java
@@ -30,7 +30,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/ImageInfo.java
+++ b/src/main/java/com/spotify/docker/client/messages/ImageInfo.java
@@ -29,7 +29,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
 import java.util.Date;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/Info.java
+++ b/src/main/java/com/spotify/docker/client/messages/Info.java
@@ -33,7 +33,7 @@ import com.spotify.docker.client.messages.swarm.SwarmInfo;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/Ipam.java
+++ b/src/main/java/com/spotify/docker/client/messages/Ipam.java
@@ -34,7 +34,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/IpamConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/IpamConfig.java
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/LogConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/LogConfig.java
@@ -30,7 +30,7 @@ import com.google.auto.value.AutoValue;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/MemoryStats.java
+++ b/src/main/java/com/spotify/docker/client/messages/MemoryStats.java
@@ -29,7 +29,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
 import java.math.BigInteger;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/Network.java
+++ b/src/main/java/com/spotify/docker/client/messages/Network.java
@@ -32,7 +32,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/NetworkConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/NetworkConfig.java
@@ -30,7 +30,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/NetworkConnection.java
+++ b/src/main/java/com/spotify/docker/client/messages/NetworkConnection.java
@@ -26,7 +26,7 @@ import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/NetworkCreation.java
+++ b/src/main/java/com/spotify/docker/client/messages/NetworkCreation.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/NetworkSettings.java
+++ b/src/main/java/com/spotify/docker/client/messages/NetworkSettings.java
@@ -33,7 +33,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/PortBinding.java
+++ b/src/main/java/com/spotify/docker/client/messages/PortBinding.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/ProcessConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/ProcessConfig.java
@@ -30,7 +30,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 /**
  * An object that represents the JSON returned by the Docker API for an exec command's process

--- a/src/main/java/com/spotify/docker/client/messages/ProgressDetail.java
+++ b/src/main/java/com/spotify/docker/client/messages/ProgressDetail.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/ProgressMessage.java
+++ b/src/main/java/com/spotify/docker/client/messages/ProgressMessage.java
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/RegistryAuth.java
+++ b/src/main/java/com/spotify/docker/client/messages/RegistryAuth.java
@@ -27,13 +27,11 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.spotify.docker.client.DockerConfigReader;
 import java.io.IOException;
-import java.nio.file.Path;
-import javax.annotation.Nullable;
-import org.glassfish.jersey.internal.util.Base64;
+import java.util.Base64;
+import jakarta.annotation.Nullable;
 
 /**
  * Represents all the auth info for a particular registry.
@@ -143,7 +141,7 @@ public abstract class RegistryAuth {
   /** Construct a Builder based upon the "auth" field of the docker client config file. */
   public static Builder forAuth(final String auth) {
     // split with limit=2 to catch case where password contains a colon
-    final String[] authParams = Base64.decodeAsString(auth).split(":", 2);
+    final String[] authParams = new String(Base64.getDecoder().decode(auth)).split(":", 2);
 
     if (authParams.length != 2) {
       return builder();

--- a/src/main/java/com/spotify/docker/client/messages/RemovedImage.java
+++ b/src/main/java/com/spotify/docker/client/messages/RemovedImage.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/ServiceCreateResponse.java
+++ b/src/main/java/com/spotify/docker/client/messages/ServiceCreateResponse.java
@@ -30,7 +30,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 
 @AutoValue

--- a/src/main/java/com/spotify/docker/client/messages/Version.java
+++ b/src/main/java/com/spotify/docker/client/messages/Version.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/Volume.java
+++ b/src/main/java/com/spotify/docker/client/messages/Volume.java
@@ -30,7 +30,7 @@ import com.google.auto.value.AutoValue;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/VolumeList.java
+++ b/src/main/java/com/spotify/docker/client/messages/VolumeList.java
@@ -30,7 +30,7 @@ import com.google.auto.value.AutoValue;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/mount/BindOptions.java
+++ b/src/main/java/com/spotify/docker/client/messages/mount/BindOptions.java
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/mount/Driver.java
+++ b/src/main/java/com/spotify/docker/client/messages/mount/Driver.java
@@ -31,7 +31,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
@@ -50,14 +50,7 @@ public abstract class Driver {
 
     public abstract Builder name(String name);
 
-    public abstract Builder options(Map<String, String> options);
-
-    abstract ImmutableMap.Builder<String, String> optionsBuilder();
-
-    public Builder addOption(final String name, final String value) {
-      optionsBuilder().put(name, value);
-      return this;
-    }
+    public abstract Builder options(@Nullable Map<String, String> options);
 
     public abstract Driver build();
   }

--- a/src/main/java/com/spotify/docker/client/messages/mount/Mount.java
+++ b/src/main/java/com/spotify/docker/client/messages/mount/Mount.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/mount/TmpfsOptions.java
+++ b/src/main/java/com/spotify/docker/client/messages/mount/TmpfsOptions.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/mount/VolumeOptions.java
+++ b/src/main/java/com/spotify/docker/client/messages/mount/VolumeOptions.java
@@ -31,7 +31,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
@@ -54,14 +54,7 @@ public abstract class VolumeOptions {
 
     public abstract Builder noCopy(Boolean noCopy);
 
-    public abstract Builder labels(Map<String, String> labels);
-
-    abstract ImmutableMap.Builder<String, String> labelsBuilder();
-
-    public Builder addLabel(final String label, final String value) {
-      labelsBuilder().put(label, value);
-      return this;
-    }
+    public abstract Builder labels(@Nullable Map<String, String> labels);
 
     public abstract Builder driverConfig(Driver driverConfig);
 

--- a/src/main/java/com/spotify/docker/client/messages/swarm/CaConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/CaConfig.java
@@ -30,7 +30,7 @@ import com.google.auto.value.AutoValue;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/swarm/Config.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/Config.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import java.util.Date;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/swarm/ConfigFile.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/ConfigFile.java
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/swarm/ConfigSpec.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/ConfigSpec.java
@@ -29,7 +29,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/swarm/ContainerSpec.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/ContainerSpec.java
@@ -34,7 +34,7 @@ import com.spotify.docker.client.messages.mount.Mount;
 
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
@@ -137,25 +137,9 @@ public abstract class ContainerSpec {
       return this;
     }
 
-    abstract ImmutableMap.Builder<String, String> labelsBuilder();
-
-    public Builder addLabel(final String label, final String value) {
-      labelsBuilder().put(label, value);
-      return this;
-    }
-
-    /**
-     * @deprecated  As of release 7.0.0, replaced by {@link #addLabel(String, String)} ()}.
-     */
-    @Deprecated
-    public Builder withLabel(final String label, final String value) {
-      addLabel(label, value);
-      return this;
-    }
-
     public abstract Builder hostname(String hostname);
 
-    public abstract Builder labels(Map<String, String> labels);
+    public abstract Builder labels(@Nullable Map<String, String> labels);
 
     public abstract Builder command(String... commands);
 

--- a/src/main/java/com/spotify/docker/client/messages/swarm/ContainerStatus.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/ContainerStatus.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/swarm/DispatcherConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/DispatcherConfig.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 
 @AutoValue

--- a/src/main/java/com/spotify/docker/client/messages/swarm/DnsConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/DnsConfig.java
@@ -30,7 +30,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/swarm/Driver.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/Driver.java
@@ -30,7 +30,7 @@ import com.google.auto.value.AutoValue;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
@@ -49,14 +49,7 @@ public abstract class Driver {
 
     public abstract Builder name(String name);
 
-    abstract ImmutableMap.Builder<String, String> optionsBuilder();
-
-    public Builder addOption(final String name, final String value) {
-      optionsBuilder().put(name, value);
-      return this;
-    }
-
-    public abstract Builder options(Map<String, String> options);
+    public abstract Builder options(@Nullable Map<String, String> options);
 
     public abstract Driver build();
   }

--- a/src/main/java/com/spotify/docker/client/messages/swarm/EncryptionConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/EncryptionConfig.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/swarm/Endpoint.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/Endpoint.java
@@ -30,7 +30,7 @@ import com.google.auto.value.AutoValue;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/swarm/EndpointSpec.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/EndpointSpec.java
@@ -31,7 +31,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/swarm/EndpointVirtualIp.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/EndpointVirtualIp.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/swarm/EngineConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/EngineConfig.java
@@ -33,7 +33,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/swarm/IpamConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/IpamConfig.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/swarm/IpamOptions.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/IpamOptions.java
@@ -30,7 +30,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/swarm/ManagerStatus.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/ManagerStatus.java
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 
 @AutoValue

--- a/src/main/java/com/spotify/docker/client/messages/swarm/NetworkAttachmentConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/NetworkAttachmentConfig.java
@@ -31,7 +31,7 @@ import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/swarm/NetworkSpec.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/NetworkSpec.java
@@ -30,7 +30,7 @@ import com.google.auto.value.AutoValue;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/swarm/Node.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/Node.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import java.util.Date;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/swarm/NodeInfo.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/NodeInfo.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import java.util.Date;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 
 @AutoValue

--- a/src/main/java/com/spotify/docker/client/messages/swarm/NodeSpec.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/NodeSpec.java
@@ -29,7 +29,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
@@ -53,14 +53,7 @@ public abstract class NodeSpec {
   public abstract static class Builder {
     public abstract Builder name(String name);
 
-    abstract ImmutableMap.Builder<String, String> labelsBuilder();
-
-    public Builder addLabel(final String label, final String value) {
-      labelsBuilder().put(label, value);
-      return this;
-    }
-
-    public abstract Builder labels(Map<String, String> labels);
+    public abstract Builder labels(@Nullable Map<String, String> labels);
 
     public abstract Builder role(String role);
 
@@ -74,7 +67,11 @@ public abstract class NodeSpec {
   }
 
   public static NodeSpec.Builder builder(final NodeSpec source) {
-    return new AutoValue_NodeSpec.Builder(source);
+    return builder()
+            .name(source.name())
+            .labels(source.labels())
+            .role(source.role())
+            .availability(source.availability());
   }
 
   @JsonCreator

--- a/src/main/java/com/spotify/docker/client/messages/swarm/NodeStatus.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/NodeStatus.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 
 @AutoValue

--- a/src/main/java/com/spotify/docker/client/messages/swarm/OrchestrationConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/OrchestrationConfig.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 
 @AutoValue

--- a/src/main/java/com/spotify/docker/client/messages/swarm/Placement.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/Placement.java
@@ -31,7 +31,7 @@ import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/swarm/Platform.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/Platform.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/swarm/PortConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/PortConfig.java
@@ -29,7 +29,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.auto.value.AutoValue;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/swarm/RaftConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/RaftConfig.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/swarm/ReplicatedService.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/ReplicatedService.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 
 @AutoValue

--- a/src/main/java/com/spotify/docker/client/messages/swarm/ResourceRequirements.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/ResourceRequirements.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/swarm/Resources.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/Resources.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/swarm/RestartPolicy.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/RestartPolicy.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/swarm/SecretFile.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/SecretFile.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/swarm/SecretSpec.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/SecretSpec.java
@@ -31,7 +31,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/swarm/Service.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/Service.java
@@ -32,7 +32,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Date;
 import java.util.Map;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
@@ -110,15 +110,8 @@ public abstract class Service {
         return this;
       }
 
-      public abstract Builder labels(final Map<String, String> labels);
-      
-      abstract ImmutableMap.Builder<String, String> labelsBuilder();
+      public abstract Builder labels(@Nullable final Map<String, String> labels);
 
-      public Builder addLabel(final String label, final String value) {
-        labelsBuilder().put(label, value);
-        return this;
-      }
-      
       public abstract Criteria build();
     }
   }

--- a/src/main/java/com/spotify/docker/client/messages/swarm/ServiceMode.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/ServiceMode.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/swarm/ServiceSpec.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/ServiceSpec.java
@@ -32,7 +32,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
@@ -79,23 +79,7 @@ public abstract class ServiceSpec {
       return this;
     }
 
-    abstract ImmutableMap.Builder<String, String> labelsBuilder();
-
-    public Builder addLabel(final String label, final String value) {
-      labelsBuilder().put(label, value);
-      return this;
-    }
-
-    /**
-     * @deprecated  As of release 7.0.0, replaced by {@link #addLabel(String, String)}.
-     */
-    @Deprecated
-    public Builder withLabel(final String label, final String value) {
-      addLabel(label, value);
-      return this;
-    }
-
-    public abstract Builder labels(Map<String, String> labels);
+    public abstract Builder labels(@Nullable Map<String, String> labels);
 
     /**
      * @deprecated  As of release 7.0.0, replaced by {@link #labels(Map)}.

--- a/src/main/java/com/spotify/docker/client/messages/swarm/SwarmCluster.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/SwarmCluster.java
@@ -31,7 +31,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import java.util.Date;
 import java.util.Map;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/swarm/SwarmInfo.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/SwarmInfo.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/swarm/SwarmInit.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/SwarmInit.java
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 
 @AutoValue

--- a/src/main/java/com/spotify/docker/client/messages/swarm/SwarmJoin.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/SwarmJoin.java
@@ -29,7 +29,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import java.util.List;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 
 @AutoValue

--- a/src/main/java/com/spotify/docker/client/messages/swarm/SwarmSpec.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/SwarmSpec.java
@@ -30,7 +30,7 @@ import com.google.auto.value.AutoValue;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/swarm/Task.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/Task.java
@@ -33,7 +33,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/swarm/TaskDefaults.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/TaskDefaults.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/swarm/TaskSpec.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/TaskSpec.java
@@ -30,7 +30,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/swarm/TaskStatus.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/TaskStatus.java
@@ -29,7 +29,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
 import java.util.Date;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/swarm/UpdateConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/UpdateConfig.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 
 @AutoValue

--- a/src/main/java/com/spotify/docker/client/messages/swarm/UpdateStatus.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/UpdateStatus.java
@@ -29,7 +29,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
 import java.util.Date;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/src/main/java/com/spotify/docker/client/messages/swarm/Version.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/Version.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 
 @AutoValue

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientUnitTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientUnitTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -88,16 +88,20 @@ import com.spotify.docker.client.messages.swarm.SwarmJoin;
 import com.spotify.docker.client.messages.swarm.Task;
 import com.spotify.docker.client.messages.swarm.TaskSpec;
 import com.spotify.docker.client.messages.swarm.Version;
+
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.sql.Date;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+
 import okhttp3.HttpUrl;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -105,7 +109,7 @@ import okhttp3.mockwebserver.RecordedRequest;
 import okio.Buffer;
 
 import org.glassfish.jersey.client.RequestEntityProcessing;
-import org.glassfish.jersey.internal.util.Base64;
+
 import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.Before;
@@ -120,7 +124,7 @@ import org.junit.rules.ExpectedException;
  * <p>
  * This test may not be a true "unit test", but using a MockWebServer where we can control the HTTP
  * responses sent by the server and capture the HTTP requests sent by the class-under-test is far
- * simpler that attempting to mock the {@link javax.ws.rs.client.Client} instance used by
+ * simpler that attempting to mock the {@link jakarta.ws.rs.client.Client} instance used by
  * DefaultDockerClient, since the Client has such a rich/fluent interface and many methods/classes
  * that would need to be mocked. Ultimately for testing DefaultDockerClient all we care about is
  * the HTTP requests it sends, rather than what HTTP client library it uses.</p>
@@ -136,1290 +140,1290 @@ import org.junit.rules.ExpectedException;
  */
 public class DefaultDockerClientUnitTest {
 
-  private final MockWebServer server = new MockWebServer();
+    private final MockWebServer server = new MockWebServer();
 
-  private DefaultDockerClient.Builder builder;
+    private DefaultDockerClient.Builder builder;
 
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
-  @Before
-  public void setup() throws Exception {
-    server.start();
+    @Before
+    public void setup() throws Exception {
+        server.start();
 
-    builder = DefaultDockerClient.builder();
-    builder.uri(server.url("/").uri());
-  }
-
-  @After
-  public void tearDown() throws Exception {
-    server.shutdown();
-  }
-
-  @Test
-  public void testHostForUnixSocket() {
-    final DefaultDockerClient client = DefaultDockerClient.builder()
-        .uri("unix:///var/run/docker.sock").build();
-    assertThat(client.getHost(), equalTo("localhost"));
-  }
-
-  @Test
-  public void testHostForLocalHttps() {
-    final DefaultDockerClient client = DefaultDockerClient.builder()
-        .uri("https://localhost:2375").build();
-    assertThat(client.getHost(), equalTo("localhost"));
-  }
-
-  @Test
-  public void testHostForFqdnHttps() {
-    final DefaultDockerClient client = DefaultDockerClient.builder()
-        .uri("https://perdu.com:2375").build();
-    assertThat(client.getHost(), equalTo("perdu.com"));
-  }
-
-  @Test
-  public void testHostForIpHttps() {
-    final DefaultDockerClient client = DefaultDockerClient.builder()
-        .uri("https://192.168.53.103:2375").build();
-    assertThat(client.getHost(), equalTo("192.168.53.103"));
-  }
-
-  @Test
-  public void testHostWithProxy() {
-    try {
-      System.setProperty("http.proxyHost", "gmodules.com");
-      System.setProperty("http.proxyPort", "80");
-      final DefaultDockerClient client = DefaultDockerClient.builder()
-              .uri("https://192.168.53.103:2375").build();
-      assertThat(client.getClient().getConfiguration()
-                      .getProperty("jersey.config.client.proxy.uri"),
-              equalTo("http://gmodules.com:80"));
-    } finally {
-      System.clearProperty("http.proxyHost");
-      System.clearProperty("http.proxyPort");
+        builder = DefaultDockerClient.builder();
+        builder.uri(server.url("/").uri());
     }
-  }
 
-  @Test
-  public void testHostWithNonProxyHost() {
-    try {
-      System.setProperty("http.proxyHost", "gmodules.com");
-      System.setProperty("http.proxyPort", "80");
-      final String nonProxyHostsPropertyValue = "127.0.0.1|localhost|192.168.*";
-      final List<String> nonProxyHostsPropertyValues = Arrays.asList(
-              nonProxyHostsPropertyValue, "\"" + nonProxyHostsPropertyValue + "\"");
-      for (String value : nonProxyHostsPropertyValues) {
-        System.setProperty("http.nonProxyHosts", value);
+    @After
+    public void tearDown() throws Exception {
+        server.shutdown();
+    }
+
+    @Test
+    public void testHostForUnixSocket() {
+        final DefaultDockerClient client = DefaultDockerClient.builder()
+                .uri("unix:///var/run/docker.sock").build();
+        assertThat(client.getHost(), equalTo("localhost"));
+    }
+
+    @Test
+    public void testHostForLocalHttps() {
+        final DefaultDockerClient client = DefaultDockerClient.builder()
+                .uri("https://localhost:2375").build();
+        assertThat(client.getHost(), equalTo("localhost"));
+    }
+
+    @Test
+    public void testHostForFqdnHttps() {
+        final DefaultDockerClient client = DefaultDockerClient.builder()
+                .uri("https://perdu.com:2375").build();
+        assertThat(client.getHost(), equalTo("perdu.com"));
+    }
+
+    @Test
+    public void testHostForIpHttps() {
         final DefaultDockerClient client = DefaultDockerClient.builder()
                 .uri("https://192.168.53.103:2375").build();
-        assertThat((String) client.getClient().getConfiguration()
-                        .getProperty("jersey.config.client.proxy.uri"),
-                isEmptyOrNullString());
-        final DefaultDockerClient client1 = DefaultDockerClient.builder()
-                .uri("https://127.0.0.1:2375").build();
-        assertThat((String) client1.getClient().getConfiguration()
-                        .getProperty("jersey.config.client.proxy.uri"),
-                isEmptyOrNullString());
-        final DefaultDockerClient client2 = DefaultDockerClient.builder()
-                .uri("https://localhost:2375").build();
-        assertThat((String) client2.getClient().getConfiguration()
-                        .getProperty("jersey.config.client.proxy.uri"),
-                isEmptyOrNullString());
-      }
-    } finally {
-      System.clearProperty("http.proxyHost");
-      System.clearProperty("http.proxyPort");
-      System.clearProperty("http.nonProxyHosts");
+        assertThat(client.getHost(), equalTo("192.168.53.103"));
     }
-  }
 
-  @Test
-  public void testProxySkippedForUnixSockets() {
-    // Set proxy properties
-    System.setProperty("http.proxyHost", "proxy.example.com");
-    System.setProperty("http.proxyPort", "8080");
-
-    try {
-      List<String> uris = Arrays.asList("unix:///var/run/docker.sock", "unix:///localhost:80");
-
-      for (String uri : uris) {
-        final DefaultDockerClient client = DefaultDockerClient.builder()
-                .uri(uri).build();
-
-        assertThat(client.getClient().getConfiguration().getProperty("jersey.config.client.proxy.uri"),
-                CoreMatchers.is(nullValue()));
-      }
-    } finally {
-      System.clearProperty("http.proxyHost");
-      System.clearProperty("http.proxyPort");
+    @Test
+    public void testHostWithProxy() {
+        try {
+            System.setProperty("http.proxyHost", "gmodules.com");
+            System.setProperty("http.proxyPort", "80");
+            final DefaultDockerClient client = DefaultDockerClient.builder()
+                    .uri("https://192.168.53.103:2375").build();
+            assertThat(client.getClient().getConfiguration()
+                            .getProperty("jersey.config.client.proxy.uri"),
+                    equalTo("http://gmodules.com:80"));
+        } finally {
+            System.clearProperty("http.proxyHost");
+            System.clearProperty("http.proxyPort");
+        }
     }
-  }
 
-  @Test
-  public void testProxySkippedForLocalhost() {
-    System.setProperty("http.proxyHost", "proxy.example.com");
-    System.setProperty("http.proxyPort", "8080");
-
-    try {
-      final DefaultDockerClient client = DefaultDockerClient.builder()
-              .uri("http://localhost:2375").build();
-      final DefaultDockerClient clientIPv6 = DefaultDockerClient.builder()
-              .uri("http://[::1]:2375").build();
-
-      assertThat(client.getClient().getConfiguration()
-              .getProperty("jersey.config.client.proxy.uri"), CoreMatchers.is(nullValue()));
-      assertThat(clientIPv6.getClient().getConfiguration()
-              .getProperty("jersey.config.client.proxy.uri"), CoreMatchers.is(nullValue()));
-    } finally {
-      System.clearProperty("http.proxyHost");
-      System.clearProperty("http.proxyPort");
+    @Test
+    public void testHostWithNonProxyHost() {
+        try {
+            System.setProperty("http.proxyHost", "gmodules.com");
+            System.setProperty("http.proxyPort", "80");
+            final String nonProxyHostsPropertyValue = "127.0.0.1|localhost|192.168.*";
+            final List<String> nonProxyHostsPropertyValues = Arrays.asList(
+                    nonProxyHostsPropertyValue, "\"" + nonProxyHostsPropertyValue + "\"");
+            for (String value : nonProxyHostsPropertyValues) {
+                System.setProperty("http.nonProxyHosts", value);
+                final DefaultDockerClient client = DefaultDockerClient.builder()
+                        .uri("https://192.168.53.103:2375").build();
+                assertThat((String) client.getClient().getConfiguration()
+                                .getProperty("jersey.config.client.proxy.uri"),
+                        isEmptyOrNullString());
+                final DefaultDockerClient client1 = DefaultDockerClient.builder()
+                        .uri("https://127.0.0.1:2375").build();
+                assertThat((String) client1.getClient().getConfiguration()
+                                .getProperty("jersey.config.client.proxy.uri"),
+                        isEmptyOrNullString());
+                final DefaultDockerClient client2 = DefaultDockerClient.builder()
+                        .uri("https://localhost:2375").build();
+                assertThat((String) client2.getClient().getConfiguration()
+                                .getProperty("jersey.config.client.proxy.uri"),
+                        isEmptyOrNullString());
+            }
+        } finally {
+            System.clearProperty("http.proxyHost");
+            System.clearProperty("http.proxyPort");
+            System.clearProperty("http.nonProxyHosts");
+        }
     }
-  }
 
-  private RecordedRequest takeRequestImmediately() throws InterruptedException {
-    return server.takeRequest(1, TimeUnit.MILLISECONDS);
-  }
+    @Test
+    public void testProxySkippedForUnixSockets() {
+        // Set proxy properties
+        System.setProperty("http.proxyHost", "proxy.example.com");
+        System.setProperty("http.proxyPort", "8080");
 
-  @Test
-  public void testCustomHeaders() throws Exception {
-    builder.header("int", 1);
-    builder.header("string", "2");
-    builder.header("list", Lists.newArrayList("a", "b", "c"));
+        try {
+            List<String> uris = Arrays.asList("unix:///var/run/docker.sock", "unix:///localhost:80");
 
-    server.enqueue(new MockResponse());
+            for (String uri : uris) {
+                final DefaultDockerClient client = DefaultDockerClient.builder()
+                        .uri(uri).build();
 
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-    dockerClient.info();
-
-    final RecordedRequest recordedRequest = takeRequestImmediately();
-    assertThat(recordedRequest.getMethod(), is("GET"));
-    assertThat(recordedRequest.getPath(), is("/info"));
-
-    assertThat(recordedRequest.getHeader("int"), is("1"));
-    assertThat(recordedRequest.getHeader("string"), is("2"));
-    // TODO (mbrown): this seems like incorrect behavior - the client should send 3 headers with
-    // name "list", not one header with a value of "[a, b, c]"
-    assertThat(recordedRequest.getHeaders().values("list"), contains("[a, b, c]"));
-  }
-
-  private static JsonNode toJson(Buffer buffer) throws IOException {
-    return ObjectMapperProvider.objectMapper().readTree(buffer.inputStream());
-  }
-
-  private static JsonNode toJson(final String string) throws IOException {
-    return ObjectMapperProvider.objectMapper().readTree(string);
-  }
-
-  private static JsonNode toJson(byte[] bytes) throws IOException {
-    return ObjectMapperProvider.objectMapper().readTree(bytes);
-  }
-
-  private static JsonNode toJson(Object object) {
-    return ObjectMapperProvider.objectMapper().valueToTree(object);
-  }
-
-  private static ObjectNode createObjectNode() {
-    return ObjectMapperProvider.objectMapper().createObjectNode();
-  }
-  
-  @Test
-  @SuppressWarnings("unchecked")
-  public void testGroupAdd() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    final HostConfig hostConfig = HostConfig.builder()
-        .groupAdd("63", "65")
-        .build();
-
-    final ContainerConfig containerConfig = ContainerConfig.builder()
-        .hostConfig(hostConfig)
-        .build();
-
-    server.enqueue(new MockResponse());
-
-    dockerClient.createContainer(containerConfig);
-
-    final RecordedRequest recordedRequest = takeRequestImmediately();
-
-    final JsonNode groupAdd = toJson(recordedRequest.getBody()).get("HostConfig").get("GroupAdd");
-    assertThat(groupAdd.isArray(), is(true));
-
-    assertThat(childrenTextNodes((ArrayNode) groupAdd), containsInAnyOrder("63", "65"));
-  }
-
-  @Test
-  @SuppressWarnings("unchecked")
-  public void testCapAddAndDrop() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    final HostConfig hostConfig = HostConfig.builder()
-        .capAdd(ImmutableList.of("foo", "bar"))
-        .capAdd(ImmutableList.of("baz", "qux"))
-        .build();
-
-    final ContainerConfig containerConfig = ContainerConfig.builder()
-        .hostConfig(hostConfig)
-        .build();
-
-    server.enqueue(new MockResponse());
-
-    dockerClient.createContainer(containerConfig);
-
-    final RecordedRequest recordedRequest = takeRequestImmediately();
-
-    assertThat(recordedRequest.getMethod(), is("POST"));
-    assertThat(recordedRequest.getPath(), is("/containers/create"));
-
-    assertThat(recordedRequest.getHeader("Content-Type"), is("application/json"));
-
-    final JsonNode requestJson = toJson(recordedRequest.getBody());
-    assertThat(requestJson, is(jsonObject()
-        .where("HostConfig", is(jsonObject()
-            .where("CapAdd", is(jsonArray(
-                containsInAnyOrder(jsonText("baz"), jsonText("qux")))))))));
-  }
-
-  private static Set<String> childrenTextNodes(ArrayNode arrayNode) {
-    final Set<String> texts = new HashSet<>();
-    for (JsonNode child : arrayNode) {
-      Preconditions.checkState(child.isTextual(),
-          "ArrayNode must only contain text nodes, but found %s in %s",
-          child.getNodeType(),
-          arrayNode);
-      texts.add(child.textValue());
+                assertThat(client.getClient().getConfiguration().getProperty("jersey.config.client.proxy.uri"),
+                        CoreMatchers.is(nullValue()));
+            }
+        } finally {
+            System.clearProperty("http.proxyHost");
+            System.clearProperty("http.proxyPort");
+        }
     }
-    return texts;
-  }
-
-  @Test
-  @SuppressWarnings("deprecated")
-  public void buildThrowsIfRegistryAuthandRegistryAuthSupplierAreBothSpecified() {
-    thrown.expect(IllegalStateException.class);
-    thrown.expectMessage("LOGIC ERROR");
 
-    final RegistryAuthSupplier authSupplier = mock(RegistryAuthSupplier.class);
-
-    //noinspection deprecation
-    DefaultDockerClient.builder()
-        .registryAuth(RegistryAuth.builder().identityToken("hello").build())
-        .registryAuthSupplier(authSupplier)
-        .build();
-  }
-
-  @Test
-  public void testBuildPassesMultipleRegistryConfigs() throws Exception {
-    final RegistryConfigs registryConfigs = RegistryConfigs.create(ImmutableMap.of(
-        "server1", RegistryAuth.builder()
-            .serverAddress("server1")
-            .username("u1")
-            .password("p1")
-            .email("e1")
-            .build(),
-
-        "server2", RegistryAuth.builder()
-            .serverAddress("server2")
-            .username("u2")
-            .password("p2")
-            .email("e2")
-            .build()
-    ));
-
-    final RegistryAuthSupplier authSupplier = mock(RegistryAuthSupplier.class);
-    when(authSupplier.authForBuild()).thenReturn(registryConfigs);
-
-    final DefaultDockerClient client = builder.registryAuthSupplier(authSupplier)
-        .build();
-
-    // build() calls /version to check what format of header to send
-    enqueueServerApiVersion("1.20");
-
-    server.enqueue(new MockResponse()
-            .setResponseCode(200)
-            .addHeader("Content-Type", "application/json")
-            .setBody(
-                fixture("fixtures/1.22/build.json")
-            )
-    );
-
-    final Path path = Paths.get(Resources.getResource("dockerDirectory").toURI());
-
-    client.build(path);
-
-    final RecordedRequest versionRequest = takeRequestImmediately();
-    assertThat(versionRequest.getMethod(), is("GET"));
-    assertThat(versionRequest.getPath(), is("/version"));
-
-    final RecordedRequest buildRequest = takeRequestImmediately();
-    assertThat(buildRequest.getMethod(), is("POST"));
-    assertThat(buildRequest.getPath(), is("/build"));
-
-    final String registryConfigHeader = buildRequest.getHeader("X-Registry-Config");
-    assertThat(registryConfigHeader, is(not(nullValue())));
-
-    // check that the JSON in the header is equivalent to what we mocked out above from
-    // the registryAuthSupplier
-    final JsonNode headerJsonNode = toJson(BaseEncoding.base64().decode(registryConfigHeader));
-    assertThat(headerJsonNode, is(toJson(registryConfigs.configs())));
-  }
-
-  @Test
-  public void testNanoCpus() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    final HostConfig hostConfig = HostConfig.builder()
-        .nanoCpus(2_000_000_000L)
-        .build();
-
-    final ContainerConfig containerConfig = ContainerConfig.builder()
-        .hostConfig(hostConfig)
-        .build();
-
-    server.enqueue(new MockResponse());
-
-    dockerClient.createContainer(containerConfig);
-
-    final RecordedRequest recordedRequest = takeRequestImmediately();
-
-    final JsonNode requestJson = toJson(recordedRequest.getBody());
-    final JsonNode nanoCpus = requestJson.get("HostConfig").get("NanoCpus");
-
-    assertThat(hostConfig.nanoCpus(), is(nanoCpus.longValue()));
-  }
-
-  @Test
-  public void testInspectNode() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    // build() calls /version to check what format of header to send
-    enqueueServerApiVersion("1.28");
-    enqueueServerApiResponse(200, "fixtures/1.28/nodeInfo.json");
-
-    final NodeInfo nodeInfo = dockerClient.inspectNode("24ifsmvkjbyhk");
-
-    assertThat(nodeInfo, notNullValue());
-    assertThat(nodeInfo.id(), is("24ifsmvkjbyhk"));
-    assertThat(nodeInfo.status(), notNullValue());
-    assertThat(nodeInfo.status().addr(), is("172.17.0.2"));
-    assertThat(nodeInfo.managerStatus(), notNullValue());
-    assertThat(nodeInfo.managerStatus().addr(), is("172.17.0.2:2377"));
-    assertThat(nodeInfo.managerStatus().leader(), is(true));
-    assertThat(nodeInfo.managerStatus().reachability(), is("reachable"));
-  }
-
-  @Test
-  public void testInspectNonLeaderNode() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    enqueueServerApiVersion("1.27");
-
-    server.enqueue(new MockResponse()
-        .setResponseCode(200)
-        .addHeader("Content-Type", "application/json")
-        .setBody(
-            fixture("fixtures/1.27/nodeInfoNonLeader.json")
-        )
-    );
-
-    NodeInfo nodeInfo = dockerClient.inspectNode("24ifsmvkjbyhk");
-    assertThat(nodeInfo, notNullValue());
-    assertThat(nodeInfo.id(), is("24ifsmvkjbyhk"));
-    assertThat(nodeInfo.status(), notNullValue());
-    assertThat(nodeInfo.status().addr(), is("172.17.0.2"));
-    assertThat(nodeInfo.managerStatus(), notNullValue());
-    assertThat(nodeInfo.managerStatus().addr(), is("172.17.0.2:2377"));
-    assertThat(nodeInfo.managerStatus().leader(), nullValue());
-    assertThat(nodeInfo.managerStatus().reachability(), is("reachable"));
-  }
-
-  @Test
-  public void testInspectNodeNonManager() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    enqueueServerApiVersion("1.27");
-
-    server.enqueue(new MockResponse()
-        .setResponseCode(200)
-        .addHeader("Content-Type", "application/json")
-        .setBody(
-            fixture("fixtures/1.27/nodeInfoNonManager.json")
-        )
-    );
-
-    NodeInfo nodeInfo = dockerClient.inspectNode("24ifsmvkjbyhk");
-    assertThat(nodeInfo, notNullValue());
-    assertThat(nodeInfo.id(), is("24ifsmvkjbyhk"));
-    assertThat(nodeInfo.status(), notNullValue());
-    assertThat(nodeInfo.status().addr(), is("172.17.0.2"));
-    assertThat(nodeInfo.managerStatus(), nullValue());
-  }
-
-  @Test(expected = NodeNotFoundException.class)
-  public void testInspectMissingNode() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    // build() calls /version to check what format of header to send
-    enqueueServerApiVersion("1.28");
-    enqueueServerApiEmptyResponse(404);
-
-    dockerClient.inspectNode("24ifsmvkjbyhk");
-  }
-
-  @Test(expected = NonSwarmNodeException.class)
-  public void testInspectNonSwarmNode() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    // build() calls /version to check what format of header to send
-    enqueueServerApiVersion("1.28");
-    enqueueServerApiEmptyResponse(503);
-
-    dockerClient.inspectNode("24ifsmvkjbyhk");
-  }
-
-  @Test
-  public void testUpdateNode() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    enqueueServerApiVersion("1.28");
-    enqueueServerApiResponse(200, "fixtures/1.28/listNodes.json");
-
-    final List<Node> nodes = dockerClient.listNodes();
-
-    assertThat(nodes.size(), is(1));
-
-    final Node node = nodes.get(0);
-
-    assertThat(node.id(), equalTo("24ifsmvkjbyhk"));
-    assertThat(node.version().index(), equalTo(8L));
-    assertThat(node.spec().name(), equalTo("my-node"));
-    assertThat(node.spec().role(), equalTo("manager"));
-    assertThat(node.spec().availability(), equalTo("active"));
-    assertThat(node.spec().labels(), hasKey(equalTo("foo")));
-
-    final NodeSpec updatedNodeSpec = NodeSpec.builder(node.spec())
-        .addLabel("foobar", "foobar")
-        .build();
-
-    enqueueServerApiVersion("1.28");
-    enqueueServerApiEmptyResponse(200);
-
-    dockerClient.updateNode(node.id(), node.version().index(), updatedNodeSpec);
-  }
-
-  @Test(expected = DockerException.class)
-  public void testUpdateNodeWithInvalidVersion() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    enqueueServerApiVersion("1.28");
-
-    final ObjectNode errorMessage = createObjectNode()
-        .put("message", "invalid node version: '7'");
-
-    enqueueServerApiResponse(500, errorMessage);
-
-    final NodeSpec nodeSpec = NodeSpec.builder()
-        .addLabel("foo", "baz")
-        .name("foobar")
-        .availability("active")
-        .role("manager")
-        .build();
-
-    dockerClient.updateNode("24ifsmvkjbyhk", 7L, nodeSpec);
-  }
-
-  @Test(expected = NodeNotFoundException.class)
-  public void testUpdateMissingNode() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    enqueueServerApiVersion("1.28");
-    enqueueServerApiError(404, "Error updating node: '24ifsmvkjbyhk'");
-
-    final NodeSpec nodeSpec = NodeSpec.builder()
-        .addLabel("foo", "baz")
-        .name("foobar")
-        .availability("active")
-        .role("manager")
-        .build();
-
-    dockerClient.updateNode("24ifsmvkjbyhk", 8L, nodeSpec);
-  }
-
-  @Test(expected = NonSwarmNodeException.class)
-  public void testUpdateNonSwarmNode() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    enqueueServerApiVersion("1.28");
-    enqueueServerApiError(503, "Error updating node: '24ifsmvkjbyhk'");
-
-    final NodeSpec nodeSpec = NodeSpec.builder()
-        .name("foobar")
-        .addLabel("foo", "baz")
-        .availability("active")
-        .role("manager")
-        .build();
-
-    dockerClient.updateNode("24ifsmvkjbyhk", 8L, nodeSpec);
-  }
-
-  @Test
-  public void testJoinSwarm() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    enqueueServerApiVersion("1.24");
-    enqueueServerApiEmptyResponse(200);
-
-    SwarmJoin swarmJoin = SwarmJoin.builder()
-            .joinToken("token_foo")
-            .listenAddr("0.0.0.0:2377")
-            .remoteAddrs(singletonList("10.0.0.10:2377"))
-            .build();
-
-    dockerClient.joinSwarm(swarmJoin);
-  }
-
-  private void enqueueServerApiError(final int statusCode, final String message) {
-    final ObjectNode errorMessage = createObjectNode()
-        .put("message", message);
-
-    enqueueServerApiResponse(statusCode, errorMessage);
-  }
-
-  @Test
-  public void testDeleteNode() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    enqueueServerApiVersion("1.24");
-    enqueueServerApiEmptyResponse(200);
-
-    dockerClient.deleteNode("node-1234");
-  }
-
-  @Test(expected = NodeNotFoundException.class)
-  public void testDeleteNode_NodeNotFound() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    enqueueServerApiVersion("1.24");
-    enqueueServerApiEmptyResponse(404);
-
-    dockerClient.deleteNode("node-1234");
-  }
-
-  @Test(expected = NonSwarmNodeException.class)
-  public void testDeleteNode_NodeNotPartOfSwarm() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    enqueueServerApiVersion("1.24");
-    enqueueServerApiEmptyResponse(503);
-
-    dockerClient.deleteNode("node-1234");
-  }
-
-  @Test
-  public void testCreateServiceWithWarnings() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    // build() calls /version to check what format of header to send
-    enqueueServerApiVersion("1.25");
-    enqueueServerApiResponse(201, "fixtures/1.25/createServiceResponse.json");
-
-    final TaskSpec taskSpec = TaskSpec.builder()
-        .containerSpec(ContainerSpec.builder()
-            .image("this_image_is_not_found_in_the_registry")
-            .build())
-        .build();
-
-    final ServiceSpec spec = ServiceSpec.builder()
-        .name("test")
-        .taskTemplate(taskSpec)
-        .build();
-
-    final ServiceCreateResponse response = dockerClient.createService(spec);
-    assertThat(response.id(), is(notNullValue()));
-    assertThat(response.warnings(), is(hasSize(1)));
-    assertThat(response.warnings(),
-        contains("unable to pin image this_image_is_not_found_in_the_registry to digest"));
-  }
-
-  @Test
-  public void testServiceLogs() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    enqueueServerApiVersion("1.25");
-
-    server.enqueue(new MockResponse()
-            .setResponseCode(200)
-            .addHeader("Content-Type", "text/plain; charset=utf-8")
-            .setBody(
-                fixture("fixtures/1.25/serviceLogs.txt")
-            )
-    );
-
-    final LogStream stream = dockerClient.serviceLogs("serviceId", DockerClient.LogsParam.stderr());
-    assertThat(stream.readFully(), is("Log Statement"));
-  }
-
-  private void enqueueServerApiEmptyResponse(final int statusCode) {
-    server.enqueue(new MockResponse()
-        .setResponseCode(statusCode)
-        .addHeader("Content-Type", "application/json")
-    );
-  }
-
-  @Test
-  public void testCreateServiceWithPlacementPreference()
-      throws IOException, DockerException, InterruptedException {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    final ImmutableList<Preference> prefs = ImmutableList.of(
-        Preference.create(
-            Spread.create(
-                "test"
-            )
-        )
-    );
-
-    final TaskSpec taskSpec = TaskSpec.builder()
-        .placement(Placement.create(null, prefs))
-        .containerSpec(ContainerSpec.builder()
-            .image("this_image_is_found_in_the_registry")
-            .build())
-        .build();
-
-    final ServiceSpec spec = ServiceSpec.builder()
-        .name("test")
-        .taskTemplate(taskSpec)
-        .build();
-
-
-    enqueueServerApiVersion("1.30");
-    enqueueServerApiResponse(201, "fixtures/1.30/createServiceResponse.json");
-
-    final ServiceCreateResponse response = dockerClient.createService(spec);
-    assertThat(response.id(), equalTo("ak7w3gjqoa3kuz8xcpnyy0pvl"));
-
-    enqueueServerApiVersion("1.30");
-    enqueueServerApiResponse(200, "fixtures/1.30/inspectCreateResponseWithPlacementPrefs.json");
-
-    final Service service = dockerClient.inspectService("ak7w3gjqoa3kuz8xcpnyy0pvl");
-    assertThat(service.spec().taskTemplate().placement(), equalTo(taskSpec.placement()));
-  }
-
-  @Test
-  public void testCreateServiceWithConfig() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    // build() calls /version to check what format of header to send
-    enqueueServerApiVersion("1.30");
-    enqueueServerApiResponse(201, "fixtures/1.30/configCreateResponse.json");
-
-    final ConfigSpec configSpec = ConfigSpec
-        .builder()
-        .data(Base64.encodeAsString("foobar"))
-        .name("foo.yaml")
-        .build();
-
-    final ConfigCreateResponse configCreateResponse = dockerClient.createConfig(configSpec);
-    assertThat(configCreateResponse.id(), equalTo("ktnbjxoalbkvbvedmg1urrz8h"));
-
-    final ConfigBind configBind = ConfigBind.builder()
-        .configName(configSpec.name())
-        .configId(configCreateResponse.id())
-        .file(ConfigFile.builder()
-          .gid("1000")
-          .uid("1000")
-          .mode(600L)
-          .name(configSpec.name())
-          .build()
-        ).build();
-
-    final TaskSpec taskSpec = TaskSpec.builder()
-        .containerSpec(ContainerSpec.builder()
-            .image("this_image_is_found_in_the_registry")
-            .configs(ImmutableList.of(configBind))
-            .build())
-        .build();
-
-    final ServiceSpec spec = ServiceSpec.builder()
-        .name("test")
-        .taskTemplate(taskSpec)
-        .build();
-
-    enqueueServerApiVersion("1.30");
-    enqueueServerApiResponse(201, "fixtures/1.30/createServiceResponse.json");
-
-    final ServiceCreateResponse response = dockerClient.createService(spec);
-    assertThat(response.id(), equalTo("ak7w3gjqoa3kuz8xcpnyy0pvl"));
-  }
-
-  @Test
-  public void testListConfigs() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    enqueueServerApiVersion("1.30");
-
-    server.enqueue(new MockResponse()
-        .setResponseCode(200)
-        .addHeader("Content-Type", "application/json")
-        .setBody(
-            fixture("fixtures/1.30/listConfigs.json")
-        )
-    );
-
-    final List<Config> configs = dockerClient.listConfigs();
-    assertThat(configs.size(), equalTo(1));
-
-    final Config config = configs.get(0);
-
-    assertThat(config, notNullValue());
-    assertThat(config.id(), equalTo("ktnbjxoalbkvbvedmg1urrz8h"));
-    assertThat(config.version().index(), equalTo(11L));
-
-    final ConfigSpec configSpec = config.configSpec();
-    assertThat(configSpec.name(), equalTo("server.conf"));
-  }
-
-  @Test
-  public void testCreateConfig() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    enqueueServerApiVersion("1.30");
-
-    server.enqueue(new MockResponse()
-        .setResponseCode(201)
-        .addHeader("Content-Type", "application/json")
-        .setBody(
-            fixture("fixtures/1.30/inspectConfig.json")
-        )
-    );
-
-    final ConfigSpec configSpec = ConfigSpec
-        .builder()
-        .data(Base64.encodeAsString("foobar"))
-        .name("foo.yaml")
-        .build();
-
-    final ConfigCreateResponse configCreateResponse = dockerClient.createConfig(configSpec);
-
-    assertThat(configCreateResponse.id(), equalTo("ktnbjxoalbkvbvedmg1urrz8h"));
-  }
-
-  @Test(expected = ConflictException.class)
-  public void testCreateConfig_ConflictingName() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    enqueueServerApiVersion("1.30");
-
-    server.enqueue(new MockResponse()
-        .setResponseCode(409)
-        .addHeader("Content-Type", "application/json")
-    );
-
-    final ConfigSpec configSpec = ConfigSpec
-        .builder()
-        .data(Base64.encodeAsString("foobar"))
-        .name("foo.yaml")
-        .build();
-
-    dockerClient.createConfig(configSpec);
-  }
-
-  @Test(expected = NonSwarmNodeException.class)
-  public void testCreateConfig_NonSwarmNode() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    enqueueServerApiVersion("1.30");
-
-    server.enqueue(new MockResponse()
-        .setResponseCode(503)
-        .addHeader("Content-Type", "application/json")
-    );
-
-    final ConfigSpec configSpec = ConfigSpec
-        .builder()
-        .data(Base64.encodeAsString("foobar"))
-        .name("foo.yaml")
-        .build();
-
-    dockerClient.createConfig(configSpec);
-  }
-
-  @Test
-  public void testInspectConfig() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    enqueueServerApiVersion("1.30");
-
-    server.enqueue(new MockResponse()
-        .setResponseCode(200)
-        .addHeader("Content-Type", "application/json")
-        .setBody(
-            fixture("fixtures/1.30/inspectConfig.json")
-        )
-    );
-
-    final Config config = dockerClient.inspectConfig("ktnbjxoalbkvbvedmg1urrz8h");
-
-    assertThat(config, notNullValue());
-    assertThat(config.id(), equalTo("ktnbjxoalbkvbvedmg1urrz8h"));
-    assertThat(config.version().index(), equalTo(11L));
-
-    final ConfigSpec configSpec = config.configSpec();
-    assertThat(configSpec.name(), equalTo("app-dev.crt"));
-  }
-
-  @Test(expected = NotFoundException.class)
-  public void testInspectConfig_NotFound() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    enqueueServerApiVersion("1.30");
-
-    server.enqueue(new MockResponse()
-        .setResponseCode(404)
-        .addHeader("Content-Type", "application/json")
-    );
-
-    dockerClient.inspectConfig("ktnbjxoalbkvbvedmg1urrz8h");
-  }
-
-  @Test(expected = NonSwarmNodeException.class)
-  public void testInspectConfig_NonSwarmNode() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    enqueueServerApiVersion("1.30");
-
-    server.enqueue(new MockResponse()
-        .setResponseCode(503)
-        .addHeader("Content-Type", "application/json")
-    );
-
-    dockerClient.inspectConfig("ktnbjxoalbkvbvedmg1urrz8h");
-  }
-
-  @Test
-  public void testDeleteConfig() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    enqueueServerApiVersion("1.30");
-
-    server.enqueue(new MockResponse()
-        .setResponseCode(204)
-        .addHeader("Content-Type", "application/json")
-    );
-
-    dockerClient.deleteConfig("ktnbjxoalbkvbvedmg1urrz8h");
-  }
-
-  @Test(expected = NotFoundException.class)
-  public void testDeleteConfig_NotFound() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    enqueueServerApiVersion("1.30");
-
-    server.enqueue(new MockResponse()
-        .setResponseCode(404)
-        .addHeader("Content-Type", "application/json")
-    );
-
-    dockerClient.deleteConfig("ktnbjxoalbkvbvedmg1urrz8h");
-  }
-
-  @Test(expected = NonSwarmNodeException.class)
-  public void testDeleteConfig_NonSwarmNode() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    enqueueServerApiVersion("1.30");
-
-    server.enqueue(new MockResponse()
-        .setResponseCode(503)
-        .addHeader("Content-Type", "application/json")
-    );
-
-    dockerClient.deleteConfig("ktnbjxoalbkvbvedmg1urrz8h");
-  }
-
-  @Test(expected = NotFoundException.class)
-  public void testUpdateConfig_NotFound() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    enqueueServerApiVersion("1.30");
-
-    server.enqueue(new MockResponse()
-        .setResponseCode(404)
-        .addHeader("Content-Type", "application/json")
-    );
-
-    final ConfigSpec configSpec = ConfigSpec
-        .builder()
-        .data(Base64.encodeAsString("foobar"))
-        .name("foo.yaml")
-        .build();
-
-    dockerClient.updateConfig("ktnbjxoalbkvbvedmg1urrz8h", 11L, configSpec);
-  }
-
-  @Test(expected = NonSwarmNodeException.class)
-  public void testUpdateConfig_NonSwarmNode() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    enqueueServerApiVersion("1.30");
-
-    server.enqueue(new MockResponse()
-        .setResponseCode(503)
-        .addHeader("Content-Type", "application/json")
-    );
-
-    final ConfigSpec configSpec = ConfigSpec
-        .builder()
-        .data(Base64.encodeAsString("foobar"))
-        .name("foo.yaml")
-        .build();
-
-    dockerClient.updateConfig("ktnbjxoalbkvbvedmg1urrz8h", 11L, configSpec);
-  }
-
-  @Test
-  public void testListNodes() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    enqueueServerApiVersion("1.28");
-
-    server.enqueue(new MockResponse()
-        .setResponseCode(200)
-        .addHeader("Content-Type", "application/json")
-        .setBody(
-            fixture("fixtures/1.28/listNodes.json")
-        )
-    );
-
-    final List<Node> nodes = dockerClient.listNodes();
-    assertThat(nodes.size(), equalTo(1));
-
-    final Node node = nodes.get(0);
-
-    assertThat(node, notNullValue());
-    assertThat(node.id(), is("24ifsmvkjbyhk"));
-    assertThat(node.version().index(), is(8L));
-
-    final NodeSpec nodeSpec = node.spec();
-    assertThat(nodeSpec.name(), is("my-node"));
-    assertThat(nodeSpec.role(), is("manager"));
-    assertThat(nodeSpec.availability(), is("active"));
-    assertThat(nodeSpec.labels().keySet(), contains("foo"));
-
-    final NodeDescription desc = node.description();
-    assertThat(desc.hostname(), is("bf3067039e47"));
-    assertThat(desc.platform().architecture(), is("x86_64"));
-    assertThat(desc.platform().os(), is("linux"));
-    assertThat(desc.resources().memoryBytes(), is(8272408576L));
-    assertThat(desc.resources().nanoCpus(), is(4000000000L));
-
-    final EngineConfig engine = desc.engine();
-    assertThat(engine.engineVersion(), is("17.04.0"));
-    assertThat(engine.labels().keySet(), contains("foo"));
-    assertThat(engine.plugins().size(), equalTo(4));
-
-    assertThat(node.status(), notNullValue());
-    assertThat(node.status().addr(), is("172.17.0.2"));
-    assertThat(node.managerStatus(), notNullValue());
-    assertThat(node.managerStatus().addr(), is("172.17.0.2:2377"));
-    assertThat(node.managerStatus().leader(), is(true));
-    assertThat(node.managerStatus().reachability(), is("reachable"));
-  }
-
-  @Test(expected = DockerException.class)
-  public void testListNodesWithServerError() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    enqueueServerApiVersion("1.28");
-
-    server.enqueue(new MockResponse()
-        .setResponseCode(500)
-        .addHeader("Content-Type", "application/json")
-    );
-
-    dockerClient.listNodes();
-  }
-  
-  @Test
-  public void testBindBuilderSelinuxLabeling() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    final Bind bindNoSelinuxLabel = HostConfig.Bind.builder()
-        .from("noselinux")
-        .to("noselinux")
-        .build();
-
-    final Bind bindSharedSelinuxContent = HostConfig.Bind.builder()
-        .from("shared")
-        .to("shared")
-        .selinuxLabeling(true)
-        .build();
-
-    final Bind bindPrivateSelinuxContent = HostConfig.Bind.builder()
-        .from("private")
-        .to("private")
-        .selinuxLabeling(false)
-        .build();
-
-    final HostConfig hostConfig = HostConfig.builder()
-        .binds(bindNoSelinuxLabel, bindSharedSelinuxContent, bindPrivateSelinuxContent)
-        .build();
-
-    final ContainerConfig containerConfig = ContainerConfig.builder()
-        .hostConfig(hostConfig)
-        .build();
-
-    server.enqueue(new MockResponse());
-
-    dockerClient.createContainer(containerConfig);
-
-    final RecordedRequest recordedRequest = takeRequestImmediately();
-
-    final JsonNode requestJson = toJson(recordedRequest.getBody());
-
-    final JsonNode binds = requestJson.get("HostConfig").get("Binds");
-
-    assertThat(binds.isArray(), is(true));
-
-    Set<String> bindSet = childrenTextNodes((ArrayNode) binds);
-    assertThat(bindSet, hasSize(3));
-
-    assertThat(bindSet, hasItem(allOf(containsString("noselinux"),
-        not(containsString("z")), not(containsString("Z")))));
-
-    assertThat(bindSet, hasItem(allOf(containsString("shared"), containsString("z"))));
-    assertThat(bindSet, hasItem(allOf(containsString("private"), containsString("Z"))));
-  }
-  
-  @Test
-  public void testKillContainer() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    server.enqueue(new MockResponse());
-
-    final Signal signal = Signal.SIGHUP;
-    dockerClient.killContainer("1234", signal);
-
-    final RecordedRequest recordedRequest = takeRequestImmediately();
-
-    final HttpUrl requestUrl = recordedRequest.getRequestUrl();
-    assertThat(requestUrl.queryParameter("signal"), equalTo(signal.toString()));
-  }
-
-  @Test
-  public void testInspectVolume() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    server.enqueue(new MockResponse()
-        .setResponseCode(200)
-        .addHeader("Content-Type", "application/json")
-        .setBody(
-            fixture("fixtures/1.33/inspectVolume.json")
-        )
-    );
-
-    final Volume volume = dockerClient.inspectVolume("my-volume");
-
-    assertThat(volume.name(), is("tardis"));
-    assertThat(volume.driver(), is("custom"));
-    assertThat(volume.mountpoint(), is("/var/lib/docker/volumes/tardis"));
-    assertThat(volume.status(), is(ImmutableMap.of("hello", "world")));
-    assertThat(volume.labels(), is(ImmutableMap.of(
-        "com.example.some-label", "some-value",
-        "com.example.some-other-label", "some-other-value"
-    )));
-    assertThat(volume.scope(), is("local"));
-    assertThat(volume.options(), is(ImmutableMap.of(
-        "foo", "bar",
-        "baz", "qux"
-    )));
-  }
-  
-  @Test
-  public void testBufferedRequestEntityProcessing() throws Exception {
-    builder.useRequestEntityProcessing(RequestEntityProcessing.BUFFERED);
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-    
-    final HostConfig hostConfig = HostConfig.builder().build();
-
-    final ContainerConfig containerConfig = ContainerConfig.builder()
-        .hostConfig(hostConfig)
-        .build();
-
-    server.enqueue(new MockResponse());
-
-    dockerClient.createContainer(containerConfig);
-
-    final RecordedRequest recordedRequest = takeRequestImmediately();
-
-    assertThat(recordedRequest.getHeader("Content-Length"), notNullValue());
-    assertThat(recordedRequest.getHeader("Transfer-Encoding"), nullValue());
-  }
-  
-  @Test
-  public void testChunkedRequestEntityProcessing() throws Exception {
-    builder.useRequestEntityProcessing(RequestEntityProcessing.CHUNKED);
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-    
-    final HostConfig hostConfig = HostConfig.builder().build();
-
-    final ContainerConfig containerConfig = ContainerConfig.builder()
-        .hostConfig(hostConfig)
-        .build();
-
-    server.enqueue(new MockResponse());
-
-    dockerClient.createContainer(containerConfig);
-
-    final RecordedRequest recordedRequest = takeRequestImmediately();
-
-    assertThat(recordedRequest.getHeader("Content-Length"), nullValue());
-    assertThat(recordedRequest.getHeader("Transfer-Encoding"), is("chunked"));
-  }
-
-  @Test
-  public void testGetDistribution() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    server.enqueue(new MockResponse()
-        .setResponseCode(200)
-        .addHeader("Content-Type", "application/json")
-        .setBody(
-          fixture("fixtures/1.30/distribution.json")
-        )
-    );
-    final Distribution distribution = dockerClient.getDistribution("my-image");
-    assertThat(distribution, notNullValue());
-    assertThat(distribution.platforms().size(), is(1));
-    assertThat(distribution.platforms().get(0).architecture(), is("amd64"));
-    assertThat(distribution.platforms().get(0).os(), is("linux"));
-    assertThat(distribution.platforms().get(0).osVersion(), is(""));
-    assertThat(distribution.platforms().get(0).variant(), is(""));
-    assertThat(distribution.descriptor().size(), is(3987495L));
-    assertThat(distribution.descriptor().digest(), is(
-        "sha256:c0537ff6a5218ef531ece93d4984efc99bbf3f7497c0a7726c88e2bb7584dc96"));
-    assertThat(distribution.descriptor().mediaType(), is(
-        "application/vnd.docker.distribution.manifest.v2+json"
-    ));
-    assertThat(distribution.platforms().get(0).osFeatures(), is(ImmutableList.of(
-        "feature1", "feature2"
-    )));
-    assertThat(distribution.platforms().get(0).features(), is(ImmutableList.of(
-        "feature1", "feature2"
-    )));
-    assertThat(distribution.descriptor().urls(), is(ImmutableList.of(
-        "url1", "url2"
-    )));
-  }
-
-  @Test
-  public void testInspectTask() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    enqueueServerApiVersion("1.24");
-    enqueueServerApiResponse(200, "fixtures/1.24/task.json");
-
-    final Task task = dockerClient.inspectTask("0kzzo1i0y4jz6027t0k7aezc7");
-
-    assertThat(task, is(pojo(Task.class)
-        .where("id", is("0kzzo1i0y4jz6027t0k7aezc7"))
-        .where("version", is(pojo(Version.class)
-            .where("index", is(71L))
-        ))
-        .where("createdAt", is(Date.from(Instant.parse("2016-06-07T21:07:31.171892745Z"))))
-        .where("updatedAt", is(Date.from(Instant.parse("2016-06-07T21:07:31.376370513Z"))))
-        .where("spec", is(pojo(TaskSpec.class)
-            .where("containerSpec", is(pojo(ContainerSpec.class)
-                .where("image", is("redis"))
-            ))
-            .where("resources", is(pojo(ResourceRequirements.class)
-                .where("limits",
-                    is(pojo(com.spotify.docker.client.messages.swarm.Resources.class)))
-                .where("reservations",
-                    is(pojo(com.spotify.docker.client.messages.swarm.Resources.class)))
-            ))
-        ))
-    ));
-  }
-
-
-  @Test
-  public void testListTaskWithCriteria() throws Exception {
-    final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
-
-    enqueueServerApiVersion("1.24");
-    enqueueServerApiResponse(200, "fixtures/1.24/tasks.json");
-    final List<Task> tasks = dockerClient.listTasks();
-    // Throw away the first request that gets the docker server version
-    takeRequestImmediately();
-    final RecordedRequest recordedRequest = takeRequestImmediately();
-    assertThat(recordedRequest.getRequestUrl().querySize(), is(0));
-    assertThat(tasks, contains(
-        pojo(Task.class)
-            .where("id", is("0kzzo1i0y4jz6027t0k7aezc7")),
-        pojo(Task.class)
-            .where("id", is("1yljwbmlr8er2waf8orvqpwms"))
-    ));
-
-    enqueueServerApiVersion("1.24");
-    enqueueServerApiResponse(200, "fixtures/1.24/tasks.json");
-    final String taskId = "task-1";
-    dockerClient.listTasks(Task.find().taskId(taskId).build());
-    takeRequestImmediately();
-    final RecordedRequest recordedRequest2 = takeRequestImmediately();
-    final HttpUrl requestUrl2 = recordedRequest2.getRequestUrl();
-    assertThat(requestUrl2.querySize(), is(1));
-    final JsonNode requestJson2 =
-        toJson(recordedRequest2.getRequestUrl().queryParameter("filters"));
-    assertThat(requestJson2, is(jsonObject()
-        .where("id", is(jsonArray(
-            contains(jsonText(taskId)))))));
-
-    enqueueServerApiVersion("1.24");
-    enqueueServerApiResponse(200, "fixtures/1.24/tasks.json");
-    final String serviceName = "service-1";
-    dockerClient.listTasks(Task.find().serviceName(serviceName).build());
-    takeRequestImmediately();
-    final RecordedRequest recordedRequest3 = takeRequestImmediately();
-    final HttpUrl requestUrl3 = recordedRequest3.getRequestUrl();
-    assertThat(requestUrl3.querySize(), is(1));
-    final JsonNode requestJson3 =
-        toJson(recordedRequest3.getRequestUrl().queryParameter("filters"));
-    assertThat(requestJson3, is(jsonObject()
-        .where("service", is(jsonArray(
-            contains(jsonText(serviceName)))))));
-  }
-
-  private void enqueueServerApiResponse(final int statusCode, final String fileName)
-      throws IOException {
-    server.enqueue(new MockResponse()
-        .setResponseCode(statusCode)
-        .addHeader("Content-Type", "application/json")
-        .setBody(
-            fixture(fileName)
-        )
-    );
-  }
-
-  private void enqueueServerApiResponse(final int statusCode, final ObjectNode objectResponse) {
-    server.enqueue(new MockResponse()
-        .setResponseCode(statusCode)
-        .addHeader("Content-Type", "application/json")
-        .setBody(
-            objectResponse.toString()
-        )
-    );
-  }
-
-  private void enqueueServerApiVersion(final String apiVersion) {
-    enqueueServerApiResponse(200,
-        createObjectNode()
-            .put("ApiVersion", apiVersion)
-            .put("Arch", "foobar")
-            .put("GitCommit", "foobar")
-            .put("GoVersion", "foobar")
-            .put("KernelVersion", "foobar")
-            .put("Os", "foobar")
-            .put("Version", "1.20")
-    );
-  }
+    @Test
+    public void testProxySkippedForLocalhost() {
+        System.setProperty("http.proxyHost", "proxy.example.com");
+        System.setProperty("http.proxyPort", "8080");
+
+        try {
+            final DefaultDockerClient client = DefaultDockerClient.builder()
+                    .uri("http://localhost:2375").build();
+            final DefaultDockerClient clientIPv6 = DefaultDockerClient.builder()
+                    .uri("http://[::1]:2375").build();
+
+            assertThat(client.getClient().getConfiguration()
+                    .getProperty("jersey.config.client.proxy.uri"), CoreMatchers.is(nullValue()));
+            assertThat(clientIPv6.getClient().getConfiguration()
+                    .getProperty("jersey.config.client.proxy.uri"), CoreMatchers.is(nullValue()));
+        } finally {
+            System.clearProperty("http.proxyHost");
+            System.clearProperty("http.proxyPort");
+        }
+    }
+
+    private RecordedRequest takeRequestImmediately() throws InterruptedException {
+        return server.takeRequest(1, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    public void testCustomHeaders() throws Exception {
+        builder.header("int", 1);
+        builder.header("string", "2");
+        builder.header("list", Lists.newArrayList("a", "b", "c"));
+
+        server.enqueue(new MockResponse());
+
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+        dockerClient.info();
+
+        final RecordedRequest recordedRequest = takeRequestImmediately();
+        assertThat(recordedRequest.getMethod(), is("GET"));
+        assertThat(recordedRequest.getPath(), is("/info"));
+
+        assertThat(recordedRequest.getHeader("int"), is("1"));
+        assertThat(recordedRequest.getHeader("string"), is("2"));
+        // TODO (mbrown): this seems like incorrect behavior - the client should send 3 headers with
+        // name "list", not one header with a value of "[a, b, c]"
+        assertThat(recordedRequest.getHeaders().values("list"), contains("[a, b, c]"));
+    }
+
+    private static JsonNode toJson(Buffer buffer) throws IOException {
+        return ObjectMapperProvider.objectMapper().readTree(buffer.inputStream());
+    }
+
+    private static JsonNode toJson(final String string) throws IOException {
+        return ObjectMapperProvider.objectMapper().readTree(string);
+    }
+
+    private static JsonNode toJson(byte[] bytes) throws IOException {
+        return ObjectMapperProvider.objectMapper().readTree(bytes);
+    }
+
+    private static JsonNode toJson(Object object) {
+        return ObjectMapperProvider.objectMapper().valueToTree(object);
+    }
+
+    private static ObjectNode createObjectNode() {
+        return ObjectMapperProvider.objectMapper().createObjectNode();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testGroupAdd() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        final HostConfig hostConfig = HostConfig.builder()
+                .groupAdd("63", "65")
+                .build();
+
+        final ContainerConfig containerConfig = ContainerConfig.builder()
+                .hostConfig(hostConfig)
+                .build();
+
+        server.enqueue(new MockResponse());
+
+        dockerClient.createContainer(containerConfig);
+
+        final RecordedRequest recordedRequest = takeRequestImmediately();
+
+        final JsonNode groupAdd = toJson(recordedRequest.getBody()).get("HostConfig").get("GroupAdd");
+        assertThat(groupAdd.isArray(), is(true));
+
+        assertThat(childrenTextNodes((ArrayNode) groupAdd), containsInAnyOrder("63", "65"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testCapAddAndDrop() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        final HostConfig hostConfig = HostConfig.builder()
+                .capAdd(ImmutableList.of("foo", "bar"))
+                .capAdd(ImmutableList.of("baz", "qux"))
+                .build();
+
+        final ContainerConfig containerConfig = ContainerConfig.builder()
+                .hostConfig(hostConfig)
+                .build();
+
+        server.enqueue(new MockResponse());
+
+        dockerClient.createContainer(containerConfig);
+
+        final RecordedRequest recordedRequest = takeRequestImmediately();
+
+        assertThat(recordedRequest.getMethod(), is("POST"));
+        assertThat(recordedRequest.getPath(), is("/containers/create"));
+
+        assertThat(recordedRequest.getHeader("Content-Type"), is("application/json"));
+
+        final JsonNode requestJson = toJson(recordedRequest.getBody());
+        assertThat(requestJson, is(jsonObject()
+                .where("HostConfig", is(jsonObject()
+                        .where("CapAdd", is(jsonArray(
+                                containsInAnyOrder(jsonText("baz"), jsonText("qux")))))))));
+    }
+
+    private static Set<String> childrenTextNodes(ArrayNode arrayNode) {
+        final Set<String> texts = new HashSet<>();
+        for (JsonNode child : arrayNode) {
+            Preconditions.checkState(child.isTextual(),
+                    "ArrayNode must only contain text nodes, but found %s in %s",
+                    child.getNodeType(),
+                    arrayNode);
+            texts.add(child.textValue());
+        }
+        return texts;
+    }
+
+    @Test
+    @SuppressWarnings("deprecated")
+    public void buildThrowsIfRegistryAuthandRegistryAuthSupplierAreBothSpecified() {
+        thrown.expect(IllegalStateException.class);
+        thrown.expectMessage("LOGIC ERROR");
+
+        final RegistryAuthSupplier authSupplier = mock(RegistryAuthSupplier.class);
+
+        //noinspection deprecation
+        DefaultDockerClient.builder()
+                .registryAuth(RegistryAuth.builder().identityToken("hello").build())
+                .registryAuthSupplier(authSupplier)
+                .build();
+    }
+
+    @Test
+    public void testBuildPassesMultipleRegistryConfigs() throws Exception {
+        final RegistryConfigs registryConfigs = RegistryConfigs.create(ImmutableMap.of(
+                "server1", RegistryAuth.builder()
+                        .serverAddress("server1")
+                        .username("u1")
+                        .password("p1")
+                        .email("e1")
+                        .build(),
+
+                "server2", RegistryAuth.builder()
+                        .serverAddress("server2")
+                        .username("u2")
+                        .password("p2")
+                        .email("e2")
+                        .build()
+        ));
+
+        final RegistryAuthSupplier authSupplier = mock(RegistryAuthSupplier.class);
+        when(authSupplier.authForBuild()).thenReturn(registryConfigs);
+
+        final DefaultDockerClient client = builder.registryAuthSupplier(authSupplier)
+                .build();
+
+        // build() calls /version to check what format of header to send
+        enqueueServerApiVersion("1.20");
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json")
+                .setBody(
+                        fixture("fixtures/1.22/build.json")
+                )
+        );
+
+        final Path path = Paths.get(Resources.getResource("dockerDirectory").toURI());
+
+        client.build(path);
+
+        final RecordedRequest versionRequest = takeRequestImmediately();
+        assertThat(versionRequest.getMethod(), is("GET"));
+        assertThat(versionRequest.getPath(), is("/version"));
+
+        final RecordedRequest buildRequest = takeRequestImmediately();
+        assertThat(buildRequest.getMethod(), is("POST"));
+        assertThat(buildRequest.getPath(), is("/build"));
+
+        final String registryConfigHeader = buildRequest.getHeader("X-Registry-Config");
+        assertThat(registryConfigHeader, is(not(nullValue())));
+
+        // check that the JSON in the header is equivalent to what we mocked out above from
+        // the registryAuthSupplier
+        final JsonNode headerJsonNode = toJson(BaseEncoding.base64().decode(registryConfigHeader));
+        assertThat(headerJsonNode, is(toJson(registryConfigs.configs())));
+    }
+
+    @Test
+    public void testNanoCpus() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        final HostConfig hostConfig = HostConfig.builder()
+                .nanoCpus(2_000_000_000L)
+                .build();
+
+        final ContainerConfig containerConfig = ContainerConfig.builder()
+                .hostConfig(hostConfig)
+                .build();
+
+        server.enqueue(new MockResponse());
+
+        dockerClient.createContainer(containerConfig);
+
+        final RecordedRequest recordedRequest = takeRequestImmediately();
+
+        final JsonNode requestJson = toJson(recordedRequest.getBody());
+        final JsonNode nanoCpus = requestJson.get("HostConfig").get("NanoCpus");
+
+        assertThat(hostConfig.nanoCpus(), is(nanoCpus.longValue()));
+    }
+
+    @Test
+    public void testInspectNode() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        // build() calls /version to check what format of header to send
+        enqueueServerApiVersion("1.28");
+        enqueueServerApiResponse(200, "fixtures/1.28/nodeInfo.json");
+
+        final NodeInfo nodeInfo = dockerClient.inspectNode("24ifsmvkjbyhk");
+
+        assertThat(nodeInfo, notNullValue());
+        assertThat(nodeInfo.id(), is("24ifsmvkjbyhk"));
+        assertThat(nodeInfo.status(), notNullValue());
+        assertThat(nodeInfo.status().addr(), is("172.17.0.2"));
+        assertThat(nodeInfo.managerStatus(), notNullValue());
+        assertThat(nodeInfo.managerStatus().addr(), is("172.17.0.2:2377"));
+        assertThat(nodeInfo.managerStatus().leader(), is(true));
+        assertThat(nodeInfo.managerStatus().reachability(), is("reachable"));
+    }
+
+    @Test
+    public void testInspectNonLeaderNode() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        enqueueServerApiVersion("1.27");
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json")
+                .setBody(
+                        fixture("fixtures/1.27/nodeInfoNonLeader.json")
+                )
+        );
+
+        NodeInfo nodeInfo = dockerClient.inspectNode("24ifsmvkjbyhk");
+        assertThat(nodeInfo, notNullValue());
+        assertThat(nodeInfo.id(), is("24ifsmvkjbyhk"));
+        assertThat(nodeInfo.status(), notNullValue());
+        assertThat(nodeInfo.status().addr(), is("172.17.0.2"));
+        assertThat(nodeInfo.managerStatus(), notNullValue());
+        assertThat(nodeInfo.managerStatus().addr(), is("172.17.0.2:2377"));
+        assertThat(nodeInfo.managerStatus().leader(), nullValue());
+        assertThat(nodeInfo.managerStatus().reachability(), is("reachable"));
+    }
+
+    @Test
+    public void testInspectNodeNonManager() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        enqueueServerApiVersion("1.27");
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json")
+                .setBody(
+                        fixture("fixtures/1.27/nodeInfoNonManager.json")
+                )
+        );
+
+        NodeInfo nodeInfo = dockerClient.inspectNode("24ifsmvkjbyhk");
+        assertThat(nodeInfo, notNullValue());
+        assertThat(nodeInfo.id(), is("24ifsmvkjbyhk"));
+        assertThat(nodeInfo.status(), notNullValue());
+        assertThat(nodeInfo.status().addr(), is("172.17.0.2"));
+        assertThat(nodeInfo.managerStatus(), nullValue());
+    }
+
+    @Test(expected = NodeNotFoundException.class)
+    public void testInspectMissingNode() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        // build() calls /version to check what format of header to send
+        enqueueServerApiVersion("1.28");
+        enqueueServerApiEmptyResponse(404);
+
+        dockerClient.inspectNode("24ifsmvkjbyhk");
+    }
+
+    @Test(expected = NonSwarmNodeException.class)
+    public void testInspectNonSwarmNode() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        // build() calls /version to check what format of header to send
+        enqueueServerApiVersion("1.28");
+        enqueueServerApiEmptyResponse(503);
+
+        dockerClient.inspectNode("24ifsmvkjbyhk");
+    }
+
+    @Test
+    public void testUpdateNode() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        enqueueServerApiVersion("1.28");
+        enqueueServerApiResponse(200, "fixtures/1.28/listNodes.json");
+
+        final List<Node> nodes = dockerClient.listNodes();
+
+        assertThat(nodes.size(), is(1));
+
+        final Node node = nodes.get(0);
+
+        assertThat(node.id(), equalTo("24ifsmvkjbyhk"));
+        assertThat(node.version().index(), equalTo(8L));
+        assertThat(node.spec().name(), equalTo("my-node"));
+        assertThat(node.spec().role(), equalTo("manager"));
+        assertThat(node.spec().availability(), equalTo("active"));
+        assertThat(node.spec().labels(), hasKey(equalTo("foo")));
+
+        final NodeSpec updatedNodeSpec = NodeSpec.builder(node.spec())
+                .labels(Map.of("foo", "baz"))
+                .build();
+
+        enqueueServerApiVersion("1.28");
+        enqueueServerApiEmptyResponse(200);
+
+        dockerClient.updateNode(node.id(), node.version().index(), updatedNodeSpec);
+    }
+
+    @Test(expected = DockerException.class)
+    public void testUpdateNodeWithInvalidVersion() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        enqueueServerApiVersion("1.28");
+
+        final ObjectNode errorMessage = createObjectNode()
+                .put("message", "invalid node version: '7'");
+
+        enqueueServerApiResponse(500, errorMessage);
+
+        final NodeSpec nodeSpec = NodeSpec.builder()
+                .labels(Map.of("foo", "baz"))
+                .name("foobar")
+                .availability("active")
+                .role("manager")
+                .build();
+
+        dockerClient.updateNode("24ifsmvkjbyhk", 7L, nodeSpec);
+    }
+
+    @Test(expected = NodeNotFoundException.class)
+    public void testUpdateMissingNode() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        enqueueServerApiVersion("1.28");
+        enqueueServerApiError(404, "Error updating node: '24ifsmvkjbyhk'");
+
+        final NodeSpec nodeSpec = NodeSpec.builder()
+                .labels(Map.of("foo", "baz"))
+                .name("foobar")
+                .availability("active")
+                .role("manager")
+                .build();
+
+        dockerClient.updateNode("24ifsmvkjbyhk", 8L, nodeSpec);
+    }
+
+    @Test(expected = NonSwarmNodeException.class)
+    public void testUpdateNonSwarmNode() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        enqueueServerApiVersion("1.28");
+        enqueueServerApiError(503, "Error updating node: '24ifsmvkjbyhk'");
+
+        final NodeSpec nodeSpec = NodeSpec.builder()
+                .name("foobar")
+                .labels(Map.of("foo", "baz"))
+                .availability("active")
+                .role("manager")
+                .build();
+
+        dockerClient.updateNode("24ifsmvkjbyhk", 8L, nodeSpec);
+    }
+
+    @Test
+    public void testJoinSwarm() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        enqueueServerApiVersion("1.24");
+        enqueueServerApiEmptyResponse(200);
+
+        SwarmJoin swarmJoin = SwarmJoin.builder()
+                .joinToken("token_foo")
+                .listenAddr("0.0.0.0:2377")
+                .remoteAddrs(singletonList("10.0.0.10:2377"))
+                .build();
+
+        dockerClient.joinSwarm(swarmJoin);
+    }
+
+    private void enqueueServerApiError(final int statusCode, final String message) {
+        final ObjectNode errorMessage = createObjectNode()
+                .put("message", message);
+
+        enqueueServerApiResponse(statusCode, errorMessage);
+    }
+
+    @Test
+    public void testDeleteNode() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        enqueueServerApiVersion("1.24");
+        enqueueServerApiEmptyResponse(200);
+
+        dockerClient.deleteNode("node-1234");
+    }
+
+    @Test(expected = NodeNotFoundException.class)
+    public void testDeleteNode_NodeNotFound() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        enqueueServerApiVersion("1.24");
+        enqueueServerApiEmptyResponse(404);
+
+        dockerClient.deleteNode("node-1234");
+    }
+
+    @Test(expected = NonSwarmNodeException.class)
+    public void testDeleteNode_NodeNotPartOfSwarm() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        enqueueServerApiVersion("1.24");
+        enqueueServerApiEmptyResponse(503);
+
+        dockerClient.deleteNode("node-1234");
+    }
+
+    @Test
+    public void testCreateServiceWithWarnings() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        // build() calls /version to check what format of header to send
+        enqueueServerApiVersion("1.25");
+        enqueueServerApiResponse(201, "fixtures/1.25/createServiceResponse.json");
+
+        final TaskSpec taskSpec = TaskSpec.builder()
+                .containerSpec(ContainerSpec.builder()
+                        .image("this_image_is_not_found_in_the_registry")
+                        .build())
+                .build();
+
+        final ServiceSpec spec = ServiceSpec.builder()
+                .name("test")
+                .taskTemplate(taskSpec)
+                .build();
+
+        final ServiceCreateResponse response = dockerClient.createService(spec);
+        assertThat(response.id(), is(notNullValue()));
+        assertThat(response.warnings(), is(hasSize(1)));
+        assertThat(response.warnings(),
+                contains("unable to pin image this_image_is_not_found_in_the_registry to digest"));
+    }
+
+    @Test
+    public void testServiceLogs() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        enqueueServerApiVersion("1.25");
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .addHeader("Content-Type", "text/plain; charset=utf-8")
+                .setBody(
+                        fixture("fixtures/1.25/serviceLogs.txt")
+                )
+        );
+
+        final LogStream stream = dockerClient.serviceLogs("serviceId", DockerClient.LogsParam.stderr());
+        assertThat(stream.readFully(), is("Log Statement"));
+    }
+
+    private void enqueueServerApiEmptyResponse(final int statusCode) {
+        server.enqueue(new MockResponse()
+                .setResponseCode(statusCode)
+                .addHeader("Content-Type", "application/json")
+        );
+    }
+
+    @Test
+    public void testCreateServiceWithPlacementPreference()
+            throws IOException, DockerException, InterruptedException {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        final ImmutableList<Preference> prefs = ImmutableList.of(
+                Preference.create(
+                        Spread.create(
+                                "test"
+                        )
+                )
+        );
+
+        final TaskSpec taskSpec = TaskSpec.builder()
+                .placement(Placement.create(null, prefs))
+                .containerSpec(ContainerSpec.builder()
+                        .image("this_image_is_found_in_the_registry")
+                        .build())
+                .build();
+
+        final ServiceSpec spec = ServiceSpec.builder()
+                .name("test")
+                .taskTemplate(taskSpec)
+                .build();
+
+
+        enqueueServerApiVersion("1.30");
+        enqueueServerApiResponse(201, "fixtures/1.30/createServiceResponse.json");
+
+        final ServiceCreateResponse response = dockerClient.createService(spec);
+        assertThat(response.id(), equalTo("ak7w3gjqoa3kuz8xcpnyy0pvl"));
+
+        enqueueServerApiVersion("1.30");
+        enqueueServerApiResponse(200, "fixtures/1.30/inspectCreateResponseWithPlacementPrefs.json");
+
+        final Service service = dockerClient.inspectService("ak7w3gjqoa3kuz8xcpnyy0pvl");
+        assertThat(service.spec().taskTemplate().placement(), equalTo(taskSpec.placement()));
+    }
+
+    @Test
+    public void testCreateServiceWithConfig() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        // build() calls /version to check what format of header to send
+        enqueueServerApiVersion("1.30");
+        enqueueServerApiResponse(201, "fixtures/1.30/configCreateResponse.json");
+
+        final ConfigSpec configSpec = ConfigSpec
+                .builder()
+                .data(Base64.getEncoder().encodeToString("foobar".getBytes()))
+                .name("foo.yaml")
+                .build();
+
+        final ConfigCreateResponse configCreateResponse = dockerClient.createConfig(configSpec);
+        assertThat(configCreateResponse.id(), equalTo("ktnbjxoalbkvbvedmg1urrz8h"));
+
+        final ConfigBind configBind = ConfigBind.builder()
+                .configName(configSpec.name())
+                .configId(configCreateResponse.id())
+                .file(ConfigFile.builder()
+                        .gid("1000")
+                        .uid("1000")
+                        .mode(600L)
+                        .name(configSpec.name())
+                        .build()
+                ).build();
+
+        final TaskSpec taskSpec = TaskSpec.builder()
+                .containerSpec(ContainerSpec.builder()
+                        .image("this_image_is_found_in_the_registry")
+                        .configs(ImmutableList.of(configBind))
+                        .build())
+                .build();
+
+        final ServiceSpec spec = ServiceSpec.builder()
+                .name("test")
+                .taskTemplate(taskSpec)
+                .build();
+
+        enqueueServerApiVersion("1.30");
+        enqueueServerApiResponse(201, "fixtures/1.30/createServiceResponse.json");
+
+        final ServiceCreateResponse response = dockerClient.createService(spec);
+        assertThat(response.id(), equalTo("ak7w3gjqoa3kuz8xcpnyy0pvl"));
+    }
+
+    @Test
+    public void testListConfigs() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        enqueueServerApiVersion("1.30");
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json")
+                .setBody(
+                        fixture("fixtures/1.30/listConfigs.json")
+                )
+        );
+
+        final List<Config> configs = dockerClient.listConfigs();
+        assertThat(configs.size(), equalTo(1));
+
+        final Config config = configs.get(0);
+
+        assertThat(config, notNullValue());
+        assertThat(config.id(), equalTo("ktnbjxoalbkvbvedmg1urrz8h"));
+        assertThat(config.version().index(), equalTo(11L));
+
+        final ConfigSpec configSpec = config.configSpec();
+        assertThat(configSpec.name(), equalTo("server.conf"));
+    }
+
+    @Test
+    public void testCreateConfig() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        enqueueServerApiVersion("1.30");
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(201)
+                .addHeader("Content-Type", "application/json")
+                .setBody(
+                        fixture("fixtures/1.30/inspectConfig.json")
+                )
+        );
+
+        final ConfigSpec configSpec = ConfigSpec
+                .builder()
+                .data(java.util.Base64.getEncoder().encodeToString("foobar".getBytes()))
+                .name("foo.yaml")
+                .build();
+
+        final ConfigCreateResponse configCreateResponse = dockerClient.createConfig(configSpec);
+
+        assertThat(configCreateResponse.id(), equalTo("ktnbjxoalbkvbvedmg1urrz8h"));
+    }
+
+    @Test(expected = ConflictException.class)
+    public void testCreateConfig_ConflictingName() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        enqueueServerApiVersion("1.30");
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(409)
+                .addHeader("Content-Type", "application/json")
+        );
+
+        final ConfigSpec configSpec = ConfigSpec
+                .builder()
+                .data(Base64.getEncoder().encodeToString("foobar".getBytes()))
+                .name("foo.yaml")
+                .build();
+
+        dockerClient.createConfig(configSpec);
+    }
+
+    @Test(expected = NonSwarmNodeException.class)
+    public void testCreateConfig_NonSwarmNode() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        enqueueServerApiVersion("1.30");
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(503)
+                .addHeader("Content-Type", "application/json")
+        );
+
+        final ConfigSpec configSpec = ConfigSpec
+                .builder()
+                .data(Base64.getEncoder().encodeToString("foobar".getBytes()))
+                .name("foo.yaml")
+                .build();
+
+        dockerClient.createConfig(configSpec);
+    }
+
+    @Test
+    public void testInspectConfig() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        enqueueServerApiVersion("1.30");
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json")
+                .setBody(
+                        fixture("fixtures/1.30/inspectConfig.json")
+                )
+        );
+
+        final Config config = dockerClient.inspectConfig("ktnbjxoalbkvbvedmg1urrz8h");
+
+        assertThat(config, notNullValue());
+        assertThat(config.id(), equalTo("ktnbjxoalbkvbvedmg1urrz8h"));
+        assertThat(config.version().index(), equalTo(11L));
+
+        final ConfigSpec configSpec = config.configSpec();
+        assertThat(configSpec.name(), equalTo("app-dev.crt"));
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void testInspectConfig_NotFound() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        enqueueServerApiVersion("1.30");
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(404)
+                .addHeader("Content-Type", "application/json")
+        );
+
+        dockerClient.inspectConfig("ktnbjxoalbkvbvedmg1urrz8h");
+    }
+
+    @Test(expected = NonSwarmNodeException.class)
+    public void testInspectConfig_NonSwarmNode() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        enqueueServerApiVersion("1.30");
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(503)
+                .addHeader("Content-Type", "application/json")
+        );
+
+        dockerClient.inspectConfig("ktnbjxoalbkvbvedmg1urrz8h");
+    }
+
+    @Test
+    public void testDeleteConfig() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        enqueueServerApiVersion("1.30");
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(204)
+                .addHeader("Content-Type", "application/json")
+        );
+
+        dockerClient.deleteConfig("ktnbjxoalbkvbvedmg1urrz8h");
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void testDeleteConfig_NotFound() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        enqueueServerApiVersion("1.30");
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(404)
+                .addHeader("Content-Type", "application/json")
+        );
+
+        dockerClient.deleteConfig("ktnbjxoalbkvbvedmg1urrz8h");
+    }
+
+    @Test(expected = NonSwarmNodeException.class)
+    public void testDeleteConfig_NonSwarmNode() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        enqueueServerApiVersion("1.30");
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(503)
+                .addHeader("Content-Type", "application/json")
+        );
+
+        dockerClient.deleteConfig("ktnbjxoalbkvbvedmg1urrz8h");
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void testUpdateConfig_NotFound() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        enqueueServerApiVersion("1.30");
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(404)
+                .addHeader("Content-Type", "application/json")
+        );
+
+        final ConfigSpec configSpec = ConfigSpec
+                .builder()
+                .data(Base64.getEncoder().encodeToString("foobar".getBytes()))
+                .name("foo.yaml")
+                .build();
+
+        dockerClient.updateConfig("ktnbjxoalbkvbvedmg1urrz8h", 11L, configSpec);
+    }
+
+    @Test(expected = NonSwarmNodeException.class)
+    public void testUpdateConfig_NonSwarmNode() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        enqueueServerApiVersion("1.30");
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(503)
+                .addHeader("Content-Type", "application/json")
+        );
+
+        final ConfigSpec configSpec = ConfigSpec
+                .builder()
+                .data(Base64.getEncoder().encodeToString("foobar".getBytes()))
+                .name("foo.yaml")
+                .build();
+
+        dockerClient.updateConfig("ktnbjxoalbkvbvedmg1urrz8h", 11L, configSpec);
+    }
+
+    @Test
+    public void testListNodes() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        enqueueServerApiVersion("1.28");
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json")
+                .setBody(
+                        fixture("fixtures/1.28/listNodes.json")
+                )
+        );
+
+        final List<Node> nodes = dockerClient.listNodes();
+        assertThat(nodes.size(), equalTo(1));
+
+        final Node node = nodes.get(0);
+
+        assertThat(node, notNullValue());
+        assertThat(node.id(), is("24ifsmvkjbyhk"));
+        assertThat(node.version().index(), is(8L));
+
+        final NodeSpec nodeSpec = node.spec();
+        assertThat(nodeSpec.name(), is("my-node"));
+        assertThat(nodeSpec.role(), is("manager"));
+        assertThat(nodeSpec.availability(), is("active"));
+        assertThat(nodeSpec.labels().keySet(), contains("foo"));
+
+        final NodeDescription desc = node.description();
+        assertThat(desc.hostname(), is("bf3067039e47"));
+        assertThat(desc.platform().architecture(), is("x86_64"));
+        assertThat(desc.platform().os(), is("linux"));
+        assertThat(desc.resources().memoryBytes(), is(8272408576L));
+        assertThat(desc.resources().nanoCpus(), is(4000000000L));
+
+        final EngineConfig engine = desc.engine();
+        assertThat(engine.engineVersion(), is("17.04.0"));
+        assertThat(engine.labels().keySet(), contains("foo"));
+        assertThat(engine.plugins().size(), equalTo(4));
+
+        assertThat(node.status(), notNullValue());
+        assertThat(node.status().addr(), is("172.17.0.2"));
+        assertThat(node.managerStatus(), notNullValue());
+        assertThat(node.managerStatus().addr(), is("172.17.0.2:2377"));
+        assertThat(node.managerStatus().leader(), is(true));
+        assertThat(node.managerStatus().reachability(), is("reachable"));
+    }
+
+    @Test(expected = DockerException.class)
+    public void testListNodesWithServerError() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        enqueueServerApiVersion("1.28");
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(500)
+                .addHeader("Content-Type", "application/json")
+        );
+
+        dockerClient.listNodes();
+    }
+
+    @Test
+    public void testBindBuilderSelinuxLabeling() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        final Bind bindNoSelinuxLabel = HostConfig.Bind.builder()
+                .from("noselinux")
+                .to("noselinux")
+                .build();
+
+        final Bind bindSharedSelinuxContent = HostConfig.Bind.builder()
+                .from("shared")
+                .to("shared")
+                .selinuxLabeling(true)
+                .build();
+
+        final Bind bindPrivateSelinuxContent = HostConfig.Bind.builder()
+                .from("private")
+                .to("private")
+                .selinuxLabeling(false)
+                .build();
+
+        final HostConfig hostConfig = HostConfig.builder()
+                .binds(bindNoSelinuxLabel, bindSharedSelinuxContent, bindPrivateSelinuxContent)
+                .build();
+
+        final ContainerConfig containerConfig = ContainerConfig.builder()
+                .hostConfig(hostConfig)
+                .build();
+
+        server.enqueue(new MockResponse());
+
+        dockerClient.createContainer(containerConfig);
+
+        final RecordedRequest recordedRequest = takeRequestImmediately();
+
+        final JsonNode requestJson = toJson(recordedRequest.getBody());
+
+        final JsonNode binds = requestJson.get("HostConfig").get("Binds");
+
+        assertThat(binds.isArray(), is(true));
+
+        Set<String> bindSet = childrenTextNodes((ArrayNode) binds);
+        assertThat(bindSet, hasSize(3));
+
+        assertThat(bindSet, hasItem(allOf(containsString("noselinux"),
+                not(containsString("z")), not(containsString("Z")))));
+
+        assertThat(bindSet, hasItem(allOf(containsString("shared"), containsString("z"))));
+        assertThat(bindSet, hasItem(allOf(containsString("private"), containsString("Z"))));
+    }
+
+    @Test
+    public void testKillContainer() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        server.enqueue(new MockResponse());
+
+        final Signal signal = Signal.SIGHUP;
+        dockerClient.killContainer("1234", signal);
+
+        final RecordedRequest recordedRequest = takeRequestImmediately();
+
+        final HttpUrl requestUrl = recordedRequest.getRequestUrl();
+        assertThat(requestUrl.queryParameter("signal"), equalTo(signal.toString()));
+    }
+
+    @Test
+    public void testInspectVolume() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json")
+                .setBody(
+                        fixture("fixtures/1.33/inspectVolume.json")
+                )
+        );
+
+        final Volume volume = dockerClient.inspectVolume("my-volume");
+
+        assertThat(volume.name(), is("tardis"));
+        assertThat(volume.driver(), is("custom"));
+        assertThat(volume.mountpoint(), is("/var/lib/docker/volumes/tardis"));
+        assertThat(volume.status(), is(ImmutableMap.of("hello", "world")));
+        assertThat(volume.labels(), is(ImmutableMap.of(
+                "com.example.some-label", "some-value",
+                "com.example.some-other-label", "some-other-value"
+        )));
+        assertThat(volume.scope(), is("local"));
+        assertThat(volume.options(), is(ImmutableMap.of(
+                "foo", "bar",
+                "baz", "qux"
+        )));
+    }
+
+    @Test
+    public void testBufferedRequestEntityProcessing() throws Exception {
+        builder.useRequestEntityProcessing(RequestEntityProcessing.BUFFERED);
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        final HostConfig hostConfig = HostConfig.builder().build();
+
+        final ContainerConfig containerConfig = ContainerConfig.builder()
+                .hostConfig(hostConfig)
+                .build();
+
+        server.enqueue(new MockResponse());
+
+        dockerClient.createContainer(containerConfig);
+
+        final RecordedRequest recordedRequest = takeRequestImmediately();
+
+        assertThat(recordedRequest.getHeader("Content-Length"), notNullValue());
+        assertThat(recordedRequest.getHeader("Transfer-Encoding"), nullValue());
+    }
+
+    @Test
+    public void testChunkedRequestEntityProcessing() throws Exception {
+        builder.useRequestEntityProcessing(RequestEntityProcessing.CHUNKED);
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        final HostConfig hostConfig = HostConfig.builder().build();
+
+        final ContainerConfig containerConfig = ContainerConfig.builder()
+                .hostConfig(hostConfig)
+                .build();
+
+        server.enqueue(new MockResponse());
+
+        dockerClient.createContainer(containerConfig);
+
+        final RecordedRequest recordedRequest = takeRequestImmediately();
+
+        assertThat(recordedRequest.getHeader("Content-Length"), nullValue());
+        assertThat(recordedRequest.getHeader("Transfer-Encoding"), is("chunked"));
+    }
+
+    @Test
+    public void testGetDistribution() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json")
+                .setBody(
+                        fixture("fixtures/1.30/distribution.json")
+                )
+        );
+        final Distribution distribution = dockerClient.getDistribution("my-image");
+        assertThat(distribution, notNullValue());
+        assertThat(distribution.platforms().size(), is(1));
+        assertThat(distribution.platforms().get(0).architecture(), is("amd64"));
+        assertThat(distribution.platforms().get(0).os(), is("linux"));
+        assertThat(distribution.platforms().get(0).osVersion(), is(""));
+        assertThat(distribution.platforms().get(0).variant(), is(""));
+        assertThat(distribution.descriptor().size(), is(3987495L));
+        assertThat(distribution.descriptor().digest(), is(
+                "sha256:c0537ff6a5218ef531ece93d4984efc99bbf3f7497c0a7726c88e2bb7584dc96"));
+        assertThat(distribution.descriptor().mediaType(), is(
+                "application/vnd.docker.distribution.manifest.v2+json"
+        ));
+        assertThat(distribution.platforms().get(0).osFeatures(), is(ImmutableList.of(
+                "feature1", "feature2"
+        )));
+        assertThat(distribution.platforms().get(0).features(), is(ImmutableList.of(
+                "feature1", "feature2"
+        )));
+        assertThat(distribution.descriptor().urls(), is(ImmutableList.of(
+                "url1", "url2"
+        )));
+    }
+
+    @Test
+    public void testInspectTask() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        enqueueServerApiVersion("1.24");
+        enqueueServerApiResponse(200, "fixtures/1.24/task.json");
+
+        final Task task = dockerClient.inspectTask("0kzzo1i0y4jz6027t0k7aezc7");
+
+        assertThat(task, is(pojo(Task.class)
+                .where("id", is("0kzzo1i0y4jz6027t0k7aezc7"))
+                .where("version", is(pojo(Version.class)
+                        .where("index", is(71L))
+                ))
+                .where("createdAt", is(Date.from(Instant.parse("2016-06-07T21:07:31.171892745Z"))))
+                .where("updatedAt", is(Date.from(Instant.parse("2016-06-07T21:07:31.376370513Z"))))
+                .where("spec", is(pojo(TaskSpec.class)
+                        .where("containerSpec", is(pojo(ContainerSpec.class)
+                                .where("image", is("redis"))
+                        ))
+                        .where("resources", is(pojo(ResourceRequirements.class)
+                                .where("limits",
+                                        is(pojo(com.spotify.docker.client.messages.swarm.Resources.class)))
+                                .where("reservations",
+                                        is(pojo(com.spotify.docker.client.messages.swarm.Resources.class)))
+                        ))
+                ))
+        ));
+    }
+
+
+    @Test
+    public void testListTaskWithCriteria() throws Exception {
+        final DefaultDockerClient dockerClient = new DefaultDockerClient(builder);
+
+        enqueueServerApiVersion("1.24");
+        enqueueServerApiResponse(200, "fixtures/1.24/tasks.json");
+        final List<Task> tasks = dockerClient.listTasks();
+        // Throw away the first request that gets the docker server version
+        takeRequestImmediately();
+        final RecordedRequest recordedRequest = takeRequestImmediately();
+        assertThat(recordedRequest.getRequestUrl().querySize(), is(0));
+        assertThat(tasks, contains(
+                pojo(Task.class)
+                        .where("id", is("0kzzo1i0y4jz6027t0k7aezc7")),
+                pojo(Task.class)
+                        .where("id", is("1yljwbmlr8er2waf8orvqpwms"))
+        ));
+
+        enqueueServerApiVersion("1.24");
+        enqueueServerApiResponse(200, "fixtures/1.24/tasks.json");
+        final String taskId = "task-1";
+        dockerClient.listTasks(Task.find().taskId(taskId).build());
+        takeRequestImmediately();
+        final RecordedRequest recordedRequest2 = takeRequestImmediately();
+        final HttpUrl requestUrl2 = recordedRequest2.getRequestUrl();
+        assertThat(requestUrl2.querySize(), is(1));
+        final JsonNode requestJson2 =
+                toJson(recordedRequest2.getRequestUrl().queryParameter("filters"));
+        assertThat(requestJson2, is(jsonObject()
+                .where("id", is(jsonArray(
+                        contains(jsonText(taskId)))))));
+
+        enqueueServerApiVersion("1.24");
+        enqueueServerApiResponse(200, "fixtures/1.24/tasks.json");
+        final String serviceName = "service-1";
+        dockerClient.listTasks(Task.find().serviceName(serviceName).build());
+        takeRequestImmediately();
+        final RecordedRequest recordedRequest3 = takeRequestImmediately();
+        final HttpUrl requestUrl3 = recordedRequest3.getRequestUrl();
+        assertThat(requestUrl3.querySize(), is(1));
+        final JsonNode requestJson3 =
+                toJson(recordedRequest3.getRequestUrl().queryParameter("filters"));
+        assertThat(requestJson3, is(jsonObject()
+                .where("service", is(jsonArray(
+                        contains(jsonText(serviceName)))))));
+    }
+
+    private void enqueueServerApiResponse(final int statusCode, final String fileName)
+            throws IOException {
+        server.enqueue(new MockResponse()
+                .setResponseCode(statusCode)
+                .addHeader("Content-Type", "application/json")
+                .setBody(
+                        fixture(fileName)
+                )
+        );
+    }
+
+    private void enqueueServerApiResponse(final int statusCode, final ObjectNode objectResponse) {
+        server.enqueue(new MockResponse()
+                .setResponseCode(statusCode)
+                .addHeader("Content-Type", "application/json")
+                .setBody(
+                        objectResponse.toString()
+                )
+        );
+    }
+
+    private void enqueueServerApiVersion(final String apiVersion) {
+        enqueueServerApiResponse(200,
+                createObjectNode()
+                        .put("ApiVersion", apiVersion)
+                        .put("Arch", "foobar")
+                        .put("GitCommit", "foobar")
+                        .put("GoVersion", "foobar")
+                        .put("KernelVersion", "foobar")
+                        .put("Os", "foobar")
+                        .put("Version", "1.20")
+        );
+    }
 }

--- a/src/test/java/com/spotify/docker/it/PushPullIT.java
+++ b/src/test/java/com/spotify/docker/it/PushPullIT.java
@@ -52,7 +52,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
-import javax.ws.rs.NotAuthorizedException;
+import jakarta.ws.rs.NotAuthorizedException;
 
 import org.junit.After;
 import org.junit.Before;


### PR DESCRIPTION
```
mszmal@CJ2HGP37WH docker-client % mvn dependency:tree | grep "javax"
mszmal@CJ2HGP37WH docker-client % 
```

```
mszmal@CJ2HGP37WH docker-client % mvn dependency:tree | grep "jakarta"

[INFO] |  +- jakarta.ws.rs:jakarta.ws.rs-api:jar:3.1.0:compile
[INFO] |  \- jakarta.inject:jakarta.inject-api:jar:2.0.1:compile
[INFO] |  +- com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:jar:2.17.2:compile
[INFO] |  \- jakarta.xml.bind:jakarta.xml.bind-api:jar:4.0.2:compile
[INFO] +- jakarta.activation:jakarta.activation-api:jar:2.1.3:compile
[INFO] +- jakarta.annotation:jakarta.annotation-api:jar:2.1.1:compile
mszmal@CJ2HGP37WH docker-client % 
```